### PR TITLE
Use bash so substitutions work for "nmake"

### DIFF
--- a/wrappers/nmake
+++ b/wrappers/nmake
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 . $(dirname $0)/msvcenv.sh
 WINEPATH=${BINDIR//\//\\} $(dirname $0)/wine-msvc.sh $BINDIR/nmake.exe "$@"


### PR DESCRIPTION
```
root@ac06aa16deab:/opt/msvc/bin/x86# /bin/sh /opt/msvc/bin/x86/nmake
/opt/msvc/bin/x86/nmake: 3: /opt/msvc/bin/x86/nmake: Bad substitution
root@ac06aa16deab:/opt/msvc/bin/x86# /bin/bash /opt/msvc/bin/x86/nmake

Microsoft (R) Program Maintenance Utility Version 14.25.28612.0
Copyright (C) Microsoft Corporation.  All rights reserved.

NMAKE : fatal error U1064: MAKEFILE not found and no target specified
Stop.
root@ac06aa16deab:/opt/msvc/bin/x86# 
```