### PR TITLE
Fix WINEPATH to include SDK bin directory

### DIFF
--- a/wrappers/msvcenv.sh
+++ b/wrappers/msvcenv.sh
@@ -15,4 +15,5 @@ SDKBINDIR=$BASE_UNIX/$SDK_UNIX/bin/$SDKVER/x64
 export INCLUDE="$MSVCDIR\\include;$SDKINCLUDE\\shared;$SDKINCLUDE\\ucrt;$SDKINCLUDE\\um;$SDKINCLUDE\\winrt"
 export LIB="$MSVCDIR\\lib\\$ARCH;$SDKLIB\\ucrt\\$ARCH;$SDKLIB\\um\\$ARCH"
 export LIBPATH="$LIB"
-export WINEPATH="${BINDIR//\//\\};${SDKBINDIR//\//\\}"
+# "$MSVCDIR\\bin\\Hostx64\\x64" is included in PATH for DLLs.
+export WINEPATH="${BINDIR//\//\\};${SDKBINDIR//\//\\};$MSVCDIR\\bin\\Hostx64\\x64"

--- a/wrappers/msvcenv.sh
+++ b/wrappers/msvcenv.sh
@@ -15,4 +15,4 @@ SDKBINDIR=$BASE_UNIX/$SDK_UNIX/bin/$SDKVER/x64
 export INCLUDE="$MSVCDIR\\include;$SDKINCLUDE\\shared;$SDKINCLUDE\\ucrt;$SDKINCLUDE\\um;$SDKINCLUDE\\winrt"
 export LIB="$MSVCDIR\\lib\\$ARCH;$SDKLIB\\ucrt\\$ARCH;$SDKLIB\\um\\$ARCH"
 export LIBPATH="$LIB"
-export WINEPATH="$MSVCDIR\\bin\\Hostx64\\x64"
+export WINEPATH="${BINDIR//\//\\};${SDKBINDIR//\//\\}"

--- a/wrappers/nmake
+++ b/wrappers/nmake
@@ -1,3 +1,3 @@
 #!/bin/bash
 . $(dirname $0)/msvcenv.sh
-WINEPATH=${BINDIR//\//\\} $(dirname $0)/wine-msvc.sh $BINDIR/nmake.exe "$@"
+$(dirname $0)/wine-msvc.sh $BINDIR/nmake.exe "$@"


### PR DESCRIPTION
The WINEPATH not correct include the vc bin directory and the SDK bin
directory, so that the compiler executables (for example nmake) can
correctly find all other tools. #10