### PR TITLE
Modify all wrappers to use bash

### DIFF
--- a/wrappers/armasm
+++ b/wrappers/armasm
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 . $(dirname $0)/msvcenv.sh
 $(dirname $0)/wine-msvc.sh $BINDIR/armasm.exe "$@"

--- a/wrappers/armasm64
+++ b/wrappers/armasm64
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 . $(dirname $0)/msvcenv.sh
 $(dirname $0)/wine-msvc.sh $BINDIR/armasm64.exe "$@"

--- a/wrappers/cl
+++ b/wrappers/cl
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 . $(dirname $0)/msvcenv.sh
 $(dirname $0)/wine-msvc.sh $BINDIR/cl.exe "$@"

--- a/wrappers/cmd
+++ b/wrappers/cmd
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "$1" = "//c" ]; then
 	shift

--- a/wrappers/dumpbin
+++ b/wrappers/dumpbin
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 . $(dirname $0)/msvcenv.sh
 $(dirname $0)/wine-msvc.sh $BINDIR/dumpbin.exe "$@"

--- a/wrappers/lib
+++ b/wrappers/lib
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 . $(dirname $0)/msvcenv.sh
 $(dirname $0)/wine-msvc.sh $BINDIR/lib.exe "$@"

--- a/wrappers/link
+++ b/wrappers/link
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 . $(dirname $0)/msvcenv.sh
 $(dirname $0)/wine-msvc.sh $BINDIR/link.exe "$@"

--- a/wrappers/msvcenv.sh
+++ b/wrappers/msvcenv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SDK=kits\\10
 SDK_UNIX=kits/10

--- a/wrappers/mt
+++ b/wrappers/mt
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 . $(dirname $0)/msvcenv.sh
 $(dirname $0)/wine-msvc.sh $SDKBINDIR/mt.exe "$@"

--- a/wrappers/rc
+++ b/wrappers/rc
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash
 . $(dirname $0)/msvcenv.sh
 $(dirname $0)/wine-msvc.sh $SDKBINDIR/rc.exe "$@"


### PR DESCRIPTION
This patch fixes the problem caused by #11 that the backslash
replacements in **msvcenv.sh** is not supported by _/bin/sh_. Considering that
the **nmake** wrapper has already been using _bash_, we changed all wrappers to use
_bash_ for consistency.

This patch is not yet tested from a clean build because of #12.