### PR TITLE
Take care of word split concerns in wine-msvc.sh

### DIFF
--- a/wrappers/wine-msvc.sh
+++ b/wrappers/wine-msvc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-EXE="$1"
+EXE=$1
 shift
-ARGS=""
+ARGS=()
 while [ $# -gt 0 ]; do
 	a=$1
 	case $a in
@@ -13,8 +13,8 @@ while [ $# -gt 0 ]; do
 	*)
 		;;
 	esac
-	ARGS="$ARGS $a"
+	ARGS+=("$a")
 	shift
 done
-wine $EXE $ARGS 2> >(grep -v '^[[:alnum:]]*:\?fixme' | grep -v ^err:bcrypt:hash_init | sed 's/\r//' >&2) | sed 's/\r//' | sed 's/z:\([\\/]\)/\1/i'
+wine "$EXE" "${ARGS[@]}" 2> >(grep -v '^[[:alnum:]]*:\?fixme' | grep -v ^err:bcrypt:hash_init | sed 's/\r//' >&2) | sed 's/\r//' | sed 's/z:\([\\/]\)/\1/i'
 exit $PIPESTATUS


### PR DESCRIPTION
This PR uses the array feature in bash to preserve word splitting in `wine-msvc.sh`. An example assuming a suitable `cmake` wrapper is in place:
```
cmake -B build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=RELWITHDEBINFO .
```

__Before:__ The word split would not be preserved when re-splitting the `ARGS` string in Line 19.
```
# cmake -B build -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=RELWITHDEBINFO .
CMake Error: Could not create named generator NMake
[...]
```

__After:__ The word split is preserved.

There are several other possible solutions to this problem, but we feel using an array is the cleanest since we are using bash here. We also converted the script to follow the word split behavior of bash (e.g., not quoting in line 2 because bash does not split in normal variable assignments).

P.S. We are adding support for parallel compilation (start `mspdbsrv.exe` to enable `/Zi`), cmake, ninja, etc. in our repo. The goal is enable out-of-the-box compilation of more packages. Right now we are still in the testing phase and we plan to issue PRs once we know the patches are stable with our test cases. Please feel free to take a look and give us feedback. Thanks!