### PR TITLE
open() manifest savefile in binary mode to make it work with Python 3

### DIFF
--- a/vsdownload.py
+++ b/vsdownload.py
@@ -146,7 +146,7 @@ def getManifest(args):
             else:
                 print("Old saved manifest in \"%s\" is still current" % (filename))
         else:
-            f = open(filename, "w")
+            f = open(filename, "wb")
             f.write(manifestdata)
             f.close()
             print("Saved installer manifest to \"%s\"" % (filename))


### PR DESCRIPTION
Fixes the following error:

```
$ ./vsdownload.py --save-manifest
Fetching https://aka.ms/vs/16/release/channel
Got toplevel manifest for 16.6.4
Loaded installer manifest for 16.6.4
Traceback (most recent call last):
  File "./vsdownload.py", line 505, in <module>
    packages = getPackages(getManifest(args))
  File "./vsdownload.py", line 150, in getManifest
    f.write(manifestdata)
TypeError: write() argument must be str, not bytes
```

Signed-off-by: Juuso Alasuutari <juuso.alasuutari@gmail.com>