### PR TITLE
Don't buffer output during download.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR /opt/msvc
 COPY lowercase fixinclude install.sh vsdownload.py ./
 COPY wrappers/* ./wrappers/
 
-RUN ./vsdownload.py --accept-license --dest /opt/msvc && \
+RUN PYTHONUNBUFFERED=1 ./vsdownload.py --accept-license --dest /opt/msvc && \
     ./install.sh /opt/msvc && \
     rm lowercase fixinclude install.sh vsdownload.py && \
     rm -rf wrappers


### PR DESCRIPTION
Helps see downloads as they happen and prevents cutting off in the middle of lines.