### PR TITLE
Broken when source files contain spaces

### DIFF
--- a/wrappers/wine-msvc.sh
+++ b/wrappers/wine-msvc.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+IFS=""
 EXE=$1
 shift
 ARGS=()


### PR DESCRIPTION
Hi, thank you for the project :-)

I know source files should have no spaces, but there is some projects that do this way. So, it is necessary to set IFS to "" in order to not break a file argument into two.