### PR TITLE
vsdownload.py - with "--save-manifest" read the old manifest in binary mode

### DIFF
--- a/vsdownload.py
+++ b/vsdownload.py
@@ -146,7 +146,7 @@ def getManifest(args):
     if args.save_manifest:
         filename = "%s.manifest" % (manifest["info"]["productDisplayVersion"])
         if os.path.isfile(filename):
-            oldfile = open(filename, "r").read()
+            oldfile = open(filename, "rb").read()
             if oldfile != manifestdata:
                 print("Old saved manifest in \"%s\" differs from newly downloaded one, not overwriting!" % (filename))
             else:


### PR DESCRIPTION
Tested with `Python 3.9.9`.
The problem doesn't appear with `Python 2.7.18`.
```
git clone https://github.com/mstorsjo/msvc-wine
./msvc-wine/vsdownload.py --accept-license --print-version --save-manifest
./msvc-wine/vsdownload.py --accept-license --print-version --save-manifest --manifest=16.11.9.manifest
```
After the last command the program prints the message:
```
Old saved manifest in "16.11.9.manifest" differs from newly downloaded one, not overwriting!
```
The local manifest differs when compared to itself.

Alternatively, the problem can be fixed by opening the old manifest in binary mode but I'm not sure if it doesn't break stuff under certain conditions.