### PR TITLE
vsdownload.py - Use six.print_(flush=True) in async function

### DIFF
--- a/vsdownload.py
+++ b/vsdownload.py
@@ -429,29 +429,29 @@ def _downloadPayload(payload, destname, fileid, allowHashMismatch):
             if os.access(destname, os.F_OK):
                 if "sha256" in payload:
                     if sha256File(destname).lower() != payload["sha256"].lower():
-                        print("Incorrect existing file %s, removing" % (fileid))
+                        six.print_("Incorrect existing file %s, removing" % (fileid), flush=True)
                         os.remove(destname)
                     else:
-                        print("Using existing file %s" % (fileid))
+                        six.print_("Using existing file %s" % (fileid), flush=True)
                         return 0
                 else:
                     return 0
             size = 0
             if "size" in payload:
                 size = payload["size"]
-            print("Downloading %s (%s)" % (fileid, formatSize(size)))
+            six.print_("Downloading %s (%s)" % (fileid, formatSize(size)), flush=True)
             six.moves.urllib.request.urlretrieve(payload["url"], destname)
             if "sha256" in payload:
                 if sha256File(destname).lower() != payload["sha256"].lower():
                     if allowHashMismatch:
-                        print("WARNING: Incorrect hash for downloaded file %s" % (fileid))
+                        six.print_("WARNING: Incorrect hash for downloaded file %s" % (fileid), flush=True)
                     else:
                         raise Exception("Incorrect hash for downloaded file %s, aborting" % fileid)
             return size
         except Exception as e:
             if attempt == attempts - 1:
                 raise
-            print("%s: %s" % (type(e).__name__, e))
+            six.print_("%s: %s" % (type(e).__name__, e), flush=True)
 
 def mergeTrees(src, dest):
     if not os.path.isdir(src):


### PR DESCRIPTION
The problem: lines printed from async function `_downloadPayload()` sometimes don't appear in the output.
The problem and the results of the tests are the same with both `Python 3.9.9` and `Python 2.7.18`.


### How to reproduce
```
git clone https://github.com/mstorsjo/msvc-wine.git
```
Get the manifest.
```
./msvc-wine/vsdownload.py --accept-license --save-manifest --print-version
```

Store the download command in a variable because it will be used a lot.
```
VSDOWNLOADCMD="\
./msvc-wine/vsdownload.py --accept-license --manifest=16.11.9.manifest --cache=cache --only-download \
  Microsoft.CodeAnalysis.ExpressionEvaluator \
  Microsoft.DiaSymReader \
  Microsoft.DiagnosticsHub.CpuSampling \
  Microsoft.DiagnosticsHub.CpuSampling.ExternalDependencies \
  Microsoft.DiagnosticsHub.CpuSampling.Resources \
  Microsoft.DiagnosticsHub.DatabaseTool.Targeted \
  Microsoft.DiagnosticsHub.DatabaseTool \
  Microsoft.DiagnosticsHub.DatabaseTool.ExternalDependencies \
  Microsoft.DiagnosticsHub.DatabaseTool.Resources \
  Microsoft.DiagnosticsHub.DatabaseTool.Targeted \
  "
```

Run the command, the packages will be downloaded.
```
$VSDOWNLOADCMD
```

Then the command should output exactly 10 of `Using existing file`.
So the following command should output `10 40 1163`.
```
$VSDOWNLOADCMD | grep "Using existing file" | wc
```


If the command is run enough times, there will be different results which means that some lines are not printed.
```
for (( i=0; i <= 100; ++i )); do
    $VSDOWNLOADCMD | grep "Using existing file" | wc
done
```

It seems like `PYTHONUNBUFFERED` doesn't completely fix the problem.
All text is printed but some newlines appear after the text.
So the command will output `13 66 1311`, `13 65 1311` and `13 64 1311`, i.e. 1-2 less words than expected.
```
for (( i=0; i <= 100; ++i )); do
    PYTHONUNBUFFERED=1 $VSDOWNLOADCMD | wc
done
```


### Solution
Adding `flush=True` to all `print()` fixes the problem but it's only available since `Python 3.3`.
https://docs.python.org/3/library/functions.html#print
Using `six.print_()` instead.
[https://six.readthedocs.io/#six.print_](https://six.readthedocs.io/#six.print_)


`PYTHONUNBUFFERED=1` is not needed with the fix.
The patch reverts changes from #17
85bb966488938eaaa9de3e24aaf3d4bdf1080345
