### PR TITLE
Change "$0" to read the executed source location to "${BASH_SOURCE[0]}

### DIFF
--- a/wrappers/msvcenv.sh
+++ b/wrappers/msvcenv.sh
@@ -2,7 +2,7 @@
 
 SDK=kits\\10
 SDK_UNIX=kits/10
-BASE_UNIX=$(cd "$(dirname "$0")"/.. && pwd)
+BASE_UNIX=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)
 # Support having the wrappers in a directory one or two levels below the
 # installation directory.
 if [ ! -d "$BASE_UNIX/vc" ]; then


### PR DESCRIPTION
Change `$0` to read the executed source location to `${BASH_SOURCE[0]}`, as the former code would not work in the case of sourcing the script because `$0` will have the value of the sourcer script.

This Stack Overflow answer thoroughly explains the difference between `$0` and `${BASH_SOURCE[0]}`: https://stackoverflow.com/a/35006505, as well as the linked answer within the above answer: https://stackoverflow.com/a/29835459.