### PR TITLE
Execute wine wrapped commands with WINEDEBUG=-all

### DIFF
--- a/wrappers/wine-msvc.sh
+++ b/wrappers/wine-msvc.sh
@@ -38,5 +38,5 @@ while [ $# -gt 0 ]; do
 	ARGS+=("$a")
 	shift
 done
-wine64 "$EXE" "${ARGS[@]}" 2> >(grep -v '^[[:alnum:]]*:\?fixme' | grep -v ^err:bcrypt:hash_init | sed 's/\r//' | sed 's/z:\([\\/]\)/\1/i' | sed '/^Note:/s,\\,/,g' >&2) | sed 's/\r//' | sed 's/z:\([\\/]\)/\1/i' | sed '/^Note:/s,\\,/,g'
+WINEDEBUG=-all wine64 "$EXE" "${ARGS[@]}" 2> >(sed 's/\r//' | sed 's/z:\([\\/]\)/\1/i' | sed '/^Note:/s,\\,/,g' >&2) | sed 's/\r//' | sed 's/z:\([\\/]\)/\1/i' | sed '/^Note:/s,\\,/,g'
 exit $PIPESTATUS


### PR DESCRIPTION
This should silence all wine debug messages, instead of just filtering out some of them.

If building with MSVC with /showDependencies, the output from /showIncludes gets printed on stderr instead of stdout, and then wine debug messages may get intermixed with the /showIncludes output, breaking dependency handling.

CC @huangqinjin - does this work for you?