### PR TITLE
Handle /notify_update in mt wrapper

### DIFF
--- a/wrappers/mt
+++ b/wrappers/mt
@@ -15,9 +15,4 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 . $(dirname $0)/msvcenv.sh
-$(dirname $0)/wine-msvc.sh $SDKBINDIR/mt.exe "${@#/notify_update}"
-
-if [[ $? == 0 && "$@" =~ '/notify_update' ]]; then
-    # https://gitlab.kitware.com/cmake/cmake/-/blob/0991023c30ed5b83bcb1446b5bcc9c1eae028835/Source/cmcmd.cxx#L2388
-    exit 187
-fi
+$(dirname $0)/wine-msvc.sh $SDKBINDIR/mt.exe "$@"

--- a/wrappers/mt
+++ b/wrappers/mt
@@ -15,4 +15,9 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 . $(dirname $0)/msvcenv.sh
-$(dirname $0)/wine-msvc.sh $SDKBINDIR/mt.exe "$@"
+$(dirname $0)/wine-msvc.sh $SDKBINDIR/mt.exe "${@#/notify_update}"
+
+if [[ $? == 0 && "$@" =~ '/notify_update' ]]; then
+    # https://gitlab.kitware.com/cmake/cmake/-/blob/0991023c30ed5b83bcb1446b5bcc9c1eae028835/Source/cmcmd.cxx#L2388
+    exit 187
+fi

--- a/wrappers/wine-msvc.bat
+++ b/wrappers/wine-msvc.bat
@@ -1,3 +1,8 @@
 @echo off
 
 %* %WINE_MSVC_ARGS% >%WINE_MSVC_STDOUT% 2>%WINE_MSVC_STDERR%
+
+REM https://gitlab.kitware.com/cmake/cmake/-/blob/0991023c30ed5b83bcb1446b5bcc9c1eae028835/Source/cmcmd.cxx#L2388
+if /I "%~n1"=="mt" (
+    if %errorlevel%==1090650113 (exit 187)
+)


### PR DESCRIPTION
CMake invokes mt.exe with the undocumented option, and mt.exe may exit with 0x41020001.

The exit code is truncated to 8 bits on POSIX hosts.

Translate exit code of mt.exe in bat file.

https://gitlab.kitware.com/cmake/cmake/-/blob/0991023c30ed5b83bcb1446b5bcc9c1eae028835/Source/cmcmd.cxx#L2533
https://gitlab.kitware.com/cmake/cmake/-/blob/0991023c30ed5b83bcb1446b5bcc9c1eae028835/Source/cmcmd.cxx#L2388

Fixes https://github.com/mstorsjo/msvc-wine/issues/45