### PR TITLE
Fix hang-up issue

### DIFF
--- a/wrappers/wine-msvc.bat
+++ b/wrappers/wine-msvc.bat
@@ -1,0 +1,3 @@
+@echo off
+
+%* %WINE_MSVC_ARGS% >%WINE_MSVC_STDOUT% 2>%WINE_MSVC_STDERR%


### PR DESCRIPTION
A single wine invocation may spawn several long-living Win32 processes automatically. These processes will inherit at least the stderr handle of current wine command and keep it open. Waiting for the wine command's stderr will hang, e.g. CMake waits for the compilation commands: https://gitlab.kitware.com/cmake/cmake/-/blob/0991023c30ed5b83bcb1446b5bcc9c1eae028835/Source/kwsys/ProcessUNIX.c#L1076

Fixes https://github.com/mstorsjo/msvc-wine/issues/47