### PR TITLE
Fix bat file arguments handling

### DIFF
--- a/wrappers/wine-msvc.bat
+++ b/wrappers/wine-msvc.bat
@@ -1,6 +1,8 @@
 @echo off
 
-%* %WINE_MSVC_ARGS% >%WINE_MSVC_STDOUT% 2>%WINE_MSVC_STDERR%
+setlocal EnableDelayedExpansion
+
+%* !WINE_MSVC_ARGS! >!WINE_MSVC_STDOUT! 2>!WINE_MSVC_STDERR!
 
 REM https://gitlab.kitware.com/cmake/cmake/-/blob/0991023c30ed5b83bcb1446b5bcc9c1eae028835/Source/cmcmd.cxx#L2388
 if /I "%~n1"=="mt" (

--- a/wrappers/wine-msvc.sh
+++ b/wrappers/wine-msvc.sh
@@ -39,7 +39,14 @@ while [ $# -gt 0 ]; do
 	shift
 done
 
-export WINE_MSVC_ARGS=$(printf ' "%s"' "${ARGS[@]}")
+if [ ${#ARGS[@]} -gt 0 ]; then
+	# 1. Escape all double-quotes.
+	# 2. Enclose each argument with double quotes.
+	# 3. Join all arguments with spaces.
+	export WINE_MSVC_ARGS=$(printf ' "%s"' "${ARGS[@]//\"/\\\"}")
+else
+	export WINE_MSVC_ARGS=
+fi
 
 unixify_path='s/\r// ; s/z:\([\\/]\)/\1/i ; /^Note:/s,\\,/,g'
 


### PR DESCRIPTION
1. Escape all double-quotes.
2. EnableDelayedExpansion for other special characters: %^&|<>

Exclamation mark ! is not handled correctly by wine cmd currently.
https://bugs.winehq.org/show_bug.cgi?id=54928