### PR TITLE
Unixify paths for more cases

### DIFF
--- a/test/test-cl.sh
+++ b/test/test-cl.sh
@@ -51,4 +51,14 @@ Note: including file: ${CWD}test.h
 EOF
 
 
+EXEC cl-P-Fi ${BIN}cl /nologo /P /Ficl-P-Fi.i ./test.c
+DIFF cl-P-Fi.i - <<EOF
+#line 1 "./test.c"
+#line 1 "${CWD}test.h"
+#line 2 "./test.c"
+ 	 #line 5 "./test.c"
+const char* file = "./test.c";
+EOF
+
+
 EXIT

--- a/test/test-cl.sh
+++ b/test/test-cl.sh
@@ -22,6 +22,8 @@ EOF
 
 cat >test.c <<EOF
 #include "test.h"
+ 	 #line 5 __FILE__
+const char* file = __FILE__;
 EOF
 
 
@@ -30,6 +32,20 @@ EXEC "" ${BIN}cl ${TESTS}hello.c
 
 EXEC cl-showIncludes ${BIN}cl /nologo /showIncludes /c test.c
 DIFF cl-showIncludes.out - <<EOF
+test.c
+Note: including file: ${CWD}test.h
+EOF
+
+
+EXEC cl-showIncludes-E-FC ${BIN}cl /nologo /showIncludes /E /FC test.c
+DIFF cl-showIncludes-E-FC.out - <<EOF
+#line 1 "${CWD}test.c"
+#line 1 "${CWD}test.h"
+#line 2 "${CWD}test.c"
+ 	 #line 5 "${CWD}test.c"
+const char* file = "Z:${CWD//\//\\\\}test.c";
+EOF
+DIFF cl-showIncludes-E-FC.err - <<EOF
 test.c
 Note: including file: ${CWD}test.h
 EOF

--- a/test/test-dumpbin.sh
+++ b/test/test-dumpbin.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018 Martin Storsjo
+# Copyright (c) 2023 Huang Qinjin
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -14,11 +14,19 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-. $(dirname $0)/msvcenv.sh
+. "${0%/*}/test.sh"
 
-# /PDBPATH
-unixify_path='/^(Dump of file |  PDB file found at )/{ s/z:([\\/])/\1/i; s,\\,/,g; }'
 
-export WINE_MSVC_STDOUT_SED="$unixify_path"
+EXEC cl-Z7 ${BIN}cl /Z7 ${TESTS}hello.c
+EXEC dumpbin-PDBPATH ${BIN}dumpbin /nologo /PDBPATH "${CWD}hello.exe"
+head -n5 dumpbin-PDBPATH.out > dumpbin-PDBPATH.out.head-n5
+DIFF dumpbin-PDBPATH.out.head-n5 - <<EOF
 
-$(dirname $0)/wine-msvc.sh $BINDIR/dumpbin.exe "$@"
+Dump of file ${CWD}hello.exe
+
+File Type: EXECUTABLE IMAGE
+  PDB file found at '${CWD}hello.pdb'
+EOF
+
+
+EXIT

--- a/test/test.sh
+++ b/test/test.sh
@@ -91,6 +91,7 @@ for arch in x86 x64 arm arm64; do
     EXEC "" BIN=$BIN ./test-cl.sh
     EXEC "" BIN=$BIN ./test-mt.sh
     EXEC "" BIN=$BIN ./test-cmake.sh
+    EXEC "" BIN=$BIN ./test-dumpbin.sh
 done
 
 EXIT

--- a/wrappers/cl
+++ b/wrappers/cl
@@ -18,8 +18,10 @@
 
 # /showIncludes
 unixify_path='/^Note: including file: /{ s/z:([\\/])/\1/i; s,\\,/,g; }'
+# /E
+unixify_line='/^[[:blank:]]*#[[:blank:]]*line[[:blank:]]/{ s/z:([\\/])/\1/i; s,\\\\,/,g; }'
 
-export WINE_MSVC_STDOUT_SED="$unixify_path"
+export WINE_MSVC_STDOUT_SED="$unixify_path;$unixify_line"
 export WINE_MSVC_STDERR_SED="$unixify_path"
 
 $(dirname $0)/wine-msvc.sh $BINDIR/cl.exe "$@"

--- a/wrappers/cl
+++ b/wrappers/cl
@@ -15,4 +15,11 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 . $(dirname $0)/msvcenv.sh
+
+# /showIncludes
+unixify_path='/^Note: including file: /{ s/z:([\\/])/\1/i; s,\\,/,g; }'
+
+export WINE_MSVC_STDOUT_SED="$unixify_path"
+export WINE_MSVC_STDERR_SED="$unixify_path"
+
 $(dirname $0)/wine-msvc.sh $BINDIR/cl.exe "$@"

--- a/wrappers/cl
+++ b/wrappers/cl
@@ -25,3 +25,26 @@ export WINE_MSVC_STDOUT_SED="$unixify_path;$unixify_line"
 export WINE_MSVC_STDERR_SED="$unixify_path"
 
 $(dirname $0)/wine-msvc.sh $BINDIR/cl.exe "$@"
+
+ec=$?
+[ $ec -ne 0 ] && exit $ec
+
+# Postprocess
+for a in "$@"; do
+    case $a in
+        [-/]P) arg_P=$a ;;
+        [-/]Fi*) arg_Fi=${a:3} ;;
+    esac
+done
+
+# Unixify paths for /P
+if [ -n "$arg_P" ] && [ -f "$arg_Fi" ]; then
+    if sed --help 2>&1 | grep '\-i extension' >/dev/null; then
+        inplace=(-i '') # BSD sed
+    else
+        inplace=(-i)    # GNU sed
+    fi
+    sed "${inplace[@]}" -E 's/\r//;'"$unixify_line" "$arg_Fi"
+fi
+
+exit $ec

--- a/wrappers/wine-msvc.sh
+++ b/wrappers/wine-msvc.sh
@@ -46,10 +46,11 @@ while [ $# -gt 0 ]; do
 	shift
 done
 
-unixify_path='s/\r// ; s/z:\([\\/]\)/\1/i ; /^Note:/s,\\,/,g'
+WINE_MSVC_STDOUT_SED='s/\r//;'"$WINE_MSVC_STDOUT_SED"
+WINE_MSVC_STDERR_SED='s/\r//;'"$WINE_MSVC_STDERR_SED"
 
 if ! $HAS_MSVCTRICKS; then
-	WINEDEBUG=-all wine64 "$EXE" "${ARGS[@]}" 2> >(sed -e "$unixify_path" >&2) | sed -e "$unixify_path"
+	WINEDEBUG=-all wine64 "$EXE" "${ARGS[@]}" 2> >(sed -E "$WINE_MSVC_STDERR_SED" >&2) | sed -E "$WINE_MSVC_STDOUT_SED"
 	exit $PIPESTATUS
 else
 	export WINE_MSVC_STDOUT=${TMPDIR:-/tmp}/wine-msvc.stdout.$$
@@ -64,7 +65,7 @@ else
 
 	cleanup && mkfifo $WINE_MSVC_STDOUT $WINE_MSVC_STDERR || exit 1
 
-	sed -e "$unixify_path" <$WINE_MSVC_STDOUT &
-	sed -e "$unixify_path" <$WINE_MSVC_STDERR >&2 &
+	sed -E "$WINE_MSVC_STDOUT_SED" <$WINE_MSVC_STDOUT &
+	sed -E "$WINE_MSVC_STDERR_SED" <$WINE_MSVC_STDERR >&2 &
 	WINEDEBUG=-all wine64 "$EXE" "${ARGS[@]}" &>/dev/null
 fi


### PR DESCRIPTION
- Unixify paths for cl /showIncludes only. Otherwise outputs may be _partially_ converted, e.g.
  ```shell
  > echo '__FILE__;' > /tmp/test.c && /opt/msvc/bin/x64/cl /nologo /E /FC /tmp/test.c
  test.c
  #line 1 "\\tmp\\test.c"
  "\\tmp\\test.c";
  ```

- Unixify paths for dumpbin /PDBPATH also. Otherwise outputs were also _partially_ converted, e.g.
  ```
  > echo 'int main() {}' > /tmp/main.c && /opt/msvc/bin/x64/cl /nologo /Z7 /tmp/main.c /Fe/tmp/main.exe && /opt/msvc/bin/x64/dumpbin /nologo /PDBPATH /tmp/main.exe
  main.c

  Dump of file \tmp\main.exe

  File Type: EXECUTABLE IMAGE
    PDB file found at '\tmp\main.pdb'
  ```

  Vcpkg use it to implement the script `vcpkg_copy_pdbs`: https://github.com/microsoft/vcpkg/blob/662dbb50e63af15baa2909b7eac5b1b87e86a0aa/scripts/cmake/vcpkg_copy_pdbs.cmake#L24

- Unixify paths for cl /P /Fi. There are three cases of `cl /P`:
  i: A output file is specified by `/Fi`. This PR handles this case and resolves #69 .
  ii. & ii: One or more source files are given to `cl /P` and an optional output directory can be specified by `/Fi` (default to CWD). `cl` will generate `{output directory}/{basename of a source file without extension}.i` for each source file. This PR does **NOT** address these cases.
