### PR TITLE
test: Test building Meson based projects with msvc-wine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          sudo apt-get update && sudo apt-get install wine64-development python3 msitools python3-simplejson python3-six ca-certificates cmake ninja-build winbind
+          sudo apt-get update && sudo apt-get install wine64-development python3 msitools python3-simplejson python3-six ca-certificates cmake ninja-build winbind meson
           wine64 wineboot
       - uses: actions/checkout@v3
       - name: Download MSVC
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          brew install wine-stable msitools cmake ninja
+          brew install wine-stable msitools cmake ninja meson
           wine64 wineboot
       - uses: actions/checkout@v3
       - name: Download MSVC

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,11 @@
+project('hello', 'c',
+    version: '1.0')
+
+if host_machine.system() == 'windows'
+    winmod = import('windows')
+    rc_obj = winmod.compile_resources('hello.rc')
+else
+    rc_obj = []
+endif
+
+executable('hello', 'hello.c', rc_obj)

--- a/test/test-meson.sh
+++ b/test/test-meson.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 Martin Storsjo
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+. "${0%/*}/test.sh"
+
+
+ARCH=$(. "${BIN}msvcenv.sh" && echo $ARCH)
+
+case $ARCH in
+x86)
+    CPU_FAMILY=x86
+    CPU=i686
+    ;;
+x64)
+    CPU_FAMILY=x86_64
+    CPU=x86_64
+    ;;
+arm)
+    CPU_FAMILY=arm
+    CPU=armv7
+    ;;
+arm64)
+    CPU_FAMILY=aarch64
+    CPU=aarch64
+    ;;
+esac
+
+cat >cross.txt <<EOF
+[binaries]
+c = 'cl'
+cpp = 'cl'
+ar = 'lib'
+windres = 'rc'
+;exe_wrapper = ['wine']
+
+[properties]
+needs_exe_wrapper = true
+
+[host_machine]
+system = 'windows'
+cpu_family = '$CPU_FAMILY'
+cpu = '$CPU'
+endian = 'little'
+EOF
+
+MESON_ARGS=(
+    --cross-file cross.txt
+)
+
+case $OSTYPE in
+    darwin*)
+        MESON_ARGS+=(
+            # No winbind package available on macOS.
+            # https://github.com/mstorsjo/msvc-wine/issues/6
+            --buildtype release
+        ) ;;
+esac
+
+export PATH="$BIN:$PATH"
+
+EXEC "" meson setup "$TESTS" "${MESON_ARGS[@]}"
+EXEC "" ninja -v
+
+# Rerun ninja to make sure that dependencies aren't broken.
+EXEC ninja-rerun ninja -d explain -v
+# Since meson 0.63.0, it generates some extra meta rules, causing the stderr
+# output not to be empty here.
+# DIFF ninja-rerun.err - <<EOF
+# EOF
+DIFF ninja-rerun.out - <<EOF
+ninja: no work to do.
+EOF
+
+
+EXIT

--- a/test/test.sh
+++ b/test/test.sh
@@ -94,6 +94,7 @@ for arch in x86 x64 arm arm64; do
     EXEC "" BIN=$BIN ./test-cl.sh
     EXEC "" BIN=$BIN ./test-mt.sh
     EXEC "" BIN=$BIN ./test-cmake.sh
+    EXEC "" BIN=$BIN ./test-meson.sh
     EXEC "" BIN=$BIN ./test-dumpbin.sh
 done
 


### PR DESCRIPTION
Only testing building with MSVC - not testing building with clang-cl with Meson. Clang-cl does work with Meson, but for the resource compiler, Meson currently fails to detect llvm-rc.

Therefore, currently if building with Meson, one has to use the Wine wrapped version of rc.exe, which requires Wine to be available, contrary to the rest of the clang-cl/lld based setup. (The CI environment for the clang/lld tests intentionally does not have Wine available.)
