### PR TITLE
test: Remove a special case for Meson testing on macOS

### DIFF
--- a/test/test-meson.sh
+++ b/test/test-meson.sh
@@ -60,15 +60,6 @@ MESON_ARGS=(
     --cross-file cross.txt
 )
 
-case $OSTYPE in
-    darwin*)
-        MESON_ARGS+=(
-            # No winbind package available on macOS.
-            # https://github.com/mstorsjo/msvc-wine/issues/6
-            --buildtype release
-        ) ;;
-esac
-
 export PATH="$BIN:$PATH"
 
 EXEC "" meson setup "$TESTS" "${MESON_ARGS[@]}"

--- a/test/test-meson.sh
+++ b/test/test-meson.sh
@@ -57,6 +57,7 @@ endian = 'little'
 EOF
 
 MESON_ARGS=(
+    --buildtype debugoptimized
     --cross-file cross.txt
 )
 


### PR DESCRIPTION
Meson doesn't use the /FS option when generating PDB debug info, which means that it doesn't use mspdbsrv.exe. Thus, the default debug mode should work fine on macOS too.