### PR TITLE
Unixify paths for cl warnings and errors

### DIFF
--- a/wrappers/cl
+++ b/wrappers/cl
@@ -20,8 +20,10 @@
 unixify_path='/^Note: including file: /{ s/z:([\\/])/\1/i; s,\\,/,g; }'
 # /E
 unixify_line='/^[[:blank:]]*#[[:blank:]]*line[[:blank:]]/{ s/z:([\\/])/\1/i; s,\\\\,/,g; }'
+# Warnings and Errors
+unixify_note='/^[zZ]:.*\([[:digit:]]+\): (note|error C[[:digit:]]{4}|warning C[[:digit:]]{4}): /{ s/z:([\\/])/\1/ig; s,\\,/,g; }'
 
-export WINE_MSVC_STDOUT_SED="$unixify_path;$unixify_line"
+export WINE_MSVC_STDOUT_SED="$unixify_path;$unixify_line;$unixify_note"
 export WINE_MSVC_STDERR_SED="$unixify_path"
 
 $(dirname $0)/wine-msvc.sh $BINDIR/cl.exe "$@"


### PR DESCRIPTION
Before:
![Screenshot_20231215_202105](https://github.com/mstorsjo/msvc-wine/assets/8402260/b2887fb8-83de-4e34-88bc-0db06129ad29)

https://github.com/mstorsjo/msvc-wine/actions/runs/7160678650/job/19503276835#step:5:322
https://github.com/mstorsjo/msvc-wine/actions/runs/7160678650/job/19503276563#step:5:322

After:
![Screenshot_20231215_201947](https://github.com/mstorsjo/msvc-wine/assets/8402260/c6f019b3-20f4-4fe0-93b4-868d6c99cd74)

https://github.com/mstorsjo/msvc-wine/actions/runs/7223373226/job/19682291627?pr=98#step:5:322
https://github.com/mstorsjo/msvc-wine/actions/runs/7223373226/job/19684065015?pr=98#step:5:322

Such that the file paths become clickable in VS Code.