### PR TITLE
Fortify WinSDK version detection in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,9 @@ fi
 ln_s Lib lib
 ln_s Include include
 cd ../..
-SDKVER=$(basename $(echo kits/10/include/* | awk '{print $NF}'))
+
+SDKVER=$(basename $(echo kits/10/include/10.* | awk '{print $NF}'))
+echo Using SDK version $SDKVER
 
 # Lowercase the SDK headers and libraries. As long as cl.exe is executed
 # within wine, this is mostly not necessary.
@@ -141,9 +143,11 @@ if [ "$(uname -m)" = "aarch64" ]; then
     host=arm64
 fi
 
-SDKVER=$(basename $(echo kits/10/include/* | awk '{print $NF}'))
 MSVCVER=$(basename $(echo vc/tools/msvc/* | awk '{print $1}'))
+echo Using MSVC version $MSVCVER
+
 cat $ORIG/wrappers/msvcenv.sh | sed 's/MSVCVER=.*/MSVCVER='$MSVCVER/ | sed 's/SDKVER=.*/SDKVER='$SDKVER/ | sed s/x64/$host/ > msvcenv.sh
+
 for arch in x86 x64 arm arm64; do
     if [ ! -d "vc/tools/msvc/$MSVCVER/bin/Hostx64/$arch" ]; then
         continue


### PR DESCRIPTION
install.sh detects the WinSDK version by scanning the common ./kits/10/include/ directory, but other kits such as WDK add non-versioned directories there, for example ./kits/10/include/wdf/.

Use a more narrow glob expression to ignore these extra directories.

Remove a redundant SDK version variable assignment and print the detected SDK and MSCV versions for diagnostics.