### PR TITLE
test: Enable mt.exe on macOS with Wine 9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          brew install wine-stable msitools cmake ninja meson
+          brew update && brew install wine-stable msitools cmake ninja meson
           wine64 wineboot
       - uses: actions/checkout@v3
       - name: Download MSVC

--- a/test/test-cmake.sh
+++ b/test/test-cmake.sh
@@ -30,9 +30,6 @@ CMAKE_ARGS=(
 case $OSTYPE in
     darwin*)
         CMAKE_ARGS+=(
-            # mt.exe always crashes on macOS.
-            -DCMAKE_EXE_LINKER_FLAGS=/MANIFEST:NO
-            -DCMAKE_SHARED_LINKER_FLAGS=/MANIFEST:NO
             # No winbind package available on macOS.
             # https://github.com/mstorsjo/msvc-wine/issues/6
             -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded

--- a/test/test-mt.sh
+++ b/test/test-mt.sh
@@ -17,13 +17,6 @@
 . "${0%/*}/test.sh"
 
 
-case $OSTYPE in
-    darwin*)
-        # mt.exe always crashes on macOS.
-        EXIT ;;
-esac
-
-
 # https://gitlab.kitware.com/cmake/cmake/-/blob/v3.26.0/Source/cmcmd.cxx#L2405
 # https://github.com/mstorsjo/msvc-wine/pull/63
 mtRetIsUpdate() {
@@ -36,8 +29,8 @@ mtRetIsUpdate() {
     fi
 }
 
-EXEC mt-notify_update-1 mtRetIsUpdate ${BIN}mt /nologo /manifest ${TESTS}utf8.manifest /out:output.manifest /notify_update
-EXEC mt-notify_update-2               ${BIN}mt /nologo /manifest ${TESTS}utf8.manifest /out:output.manifest /notify_update
+EXEC "" mtRetIsUpdate ${BIN}mt /nologo /manifest ${TESTS}utf8.manifest /out:output.manifest /notify_update
+EXEC ""               ${BIN}mt /nologo /manifest ${TESTS}utf8.manifest /out:output.manifest /notify_update
 
 
 EXIT


### PR DESCRIPTION
mt.exe no longer crashes on macOS with Wine 9.0.

macOS-12 runner image version 20240119 has updated to Wine 9.0.
https://github.com/huangqinjin/msvc-wine/actions/runs/7583317817/job/20752571482

 Let's wait until most runners have been upgraded.
