### PR TITLE
msbuild: Prefer x86_64 build tools for all targets

### DIFF
--- a/wrappers/msbuild
+++ b/wrappers/msbuild
@@ -66,5 +66,10 @@ arm64)
     ;;
 esac
 
+if [[ "${MSBUILDBINDIR}" == *amd64 ]]; then
+    # Prefer x86_64 build tools for any target arch.
+    export PreferredToolArchitecture=x64
+fi
+
 export WINE_MSVC_RAW_STDOUT=1
 $(dirname $0)/wine-msvc.sh ${MSBUILDBINDIR}/MSBuild.exe "$@"


### PR DESCRIPTION
Set a global MSBuild property to always prefer 64-bit build tools.

Reference:
https://learn.microsoft.com/en-us/cpp/build/reference/msbuild-visual-cpp-overview?view=msvc-170#preferredtoolarchitecture-property

Resolves #108