### PR TITLE
Revert "github: Run brew update to get latest softwares"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          brew update && brew install wine-stable msitools cmake ninja meson
+          brew install wine-stable msitools cmake ninja meson
           wine64 wineboot
           curl -s -L -O https://github.com/madewokherd/wine-mono/releases/download/wine-mono-9.0.0/wine-mono-9.0.0-x86.msi
           wine64 msiexec /i wine-mono-9.0.0-x86.msi


### PR DESCRIPTION
This reverts commit 26d574b051ddf4642cf92fb92e921c0561196b8a.

Running `brew update` breaks macos-12 runner version 20240202.
It was needed at that moment to get latest wine 9.0 but now it is no longer needed.