### PR TITLE
Drop unmaintained Python 2 support via six

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install prerequisites
         run: |
           sudo dpkg --add-architecture i386 && sudo apt-get update
-          sudo apt-get install wine64 wine32 python3 msitools python3-simplejson python3-six ca-certificates cmake ninja-build winbind meson
+          sudo apt-get install wine64 wine32 python3 msitools ca-certificates cmake ninja-build winbind meson
           wine64 wineboot
           curl -s -L -O https://github.com/madewokherd/wine-mono/releases/download/wine-mono-5.1.1/wine-mono-5.1.1-x86.msi
           wine64 msiexec /i wine-mono-5.1.1-x86.msi
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          sudo apt-get update && sudo apt-get install python3 msitools python3-simplejson python3-six ca-certificates clang lld llvm cmake ninja-build
+          sudo apt-get update && sudo apt-get install python3 msitools ca-certificates clang lld llvm cmake ninja-build
       - name: Set up clang-cl/lld-link symlinks
         run: |
           if [ ! -e /usr/bin/clang-cl ]; then

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          sudo apt-get update && sudo apt-get install wine64-development python3 msitools python3-simplejson python3-six ca-certificates ninja-build winbind meson nasm
+          sudo apt-get update && sudo apt-get install wine64-development python3 msitools ca-certificates ninja-build winbind meson nasm
           wine64 wineboot
       - uses: actions/checkout@v4
       - name: Download MSVC
@@ -78,7 +78,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          sudo apt-get update && sudo apt-get install wine64-development python3 msitools python3-simplejson python3-six ca-certificates winbind nasm
+          sudo apt-get update && sudo apt-get install wine64-development python3 msitools ca-certificates winbind nasm
           wine64 wineboot
       - uses: actions/checkout@v4
       - name: Download MSVC
@@ -122,7 +122,7 @@ jobs:
     steps:
       - name: Install prerequisites
         run: |
-          sudo apt-get update && sudo apt-get install wine64-development python3 msitools python3-simplejson python3-six ca-certificates cmake ninja-build winbind
+          sudo apt-get update && sudo apt-get install wine64-development python3 msitools ca-certificates cmake ninja-build winbind
           wine64 wineboot
       - uses: actions/checkout@v4
       - name: Download MSVC

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && \
-    apt-get install -y wine64-development python3 msitools python3-simplejson \
-                       python3-six ca-certificates && \
+    apt-get install -y wine64-development python3 msitools ca-certificates && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following instructions are for setting up MSVC without docker.
 
 ```bash
 apt-get update
-apt-get install -y wine64-development python3 msitools python3-simplejson python3-six ca-certificates winbind
+apt-get install -y wine64-development python3 msitools ca-certificates winbind
 ```
 
 ## Installation
@@ -89,7 +89,7 @@ as usual. You need less prerequisites as wine won't be needed:
 
 ```bash
 apt-get update
-apt-get install -y python3 msitools python3-simplejson python3-six ca-certificates
+apt-get install -y python3 msitools ca-certificates
 
 # Download and unpack MSVC
 ./vsdownload.py --dest ~/my_msvc


### PR DESCRIPTION
Python 3 style print functions are already used throughout the codebase, and only a few places use six.
Python 2 compatibility is not longer there.

Use the standard `json` module in place of `simplejson`.