### PR TITLE
fixinclude: Match include lines with leading spaces

### DIFF
--- a/fixinclude
+++ b/fixinclude
@@ -44,7 +44,7 @@ sub dodir($) {
       while(my $line = <FHIN>) {
         # Make sure to match '#include <foo>' or '#include "bar"', but not
         # '#include IDENTIFIER'.
-        if($line =~ m/^#\s*include\s+["<][\w\.\/\\]+[">]/) {
+        if($line =~ m/^\s*#\s*include\s+["<][\w\.\/\\]+[">]/) {
           my @values = split('//', $line);
           $values[0] =~ tr [A-Z\\] [a-z/];
 

--- a/test/headers.cpp
+++ b/test/headers.cpp
@@ -21,3 +21,7 @@
 // This includes MSVC STL headers, which strictly require a very recent
 // version of Clang.
 #include <comdef.h>
+
+// gdiplus.h has include statements that we previously didn't fix the
+// casing for.
+#include <gdiplus.h>


### PR DESCRIPTION
This style is present in gdiplus.h.

This should hopefully fix #123.