### PR TITLE
Support `import std` for CMake

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -164,6 +164,11 @@ fi
 MSVCVER=$(basename $(echo vc/tools/msvc/* | awk '{print $1}'))
 echo Using MSVC version $MSVCVER
 
+# Support `import std` for CMake.
+if [ -d "VC/Tools/MSVC/$MSVCVER/modules" ]; then
+    ln_s VC/Tools/MSVC/$MSVCVER/modules modules
+fi
+
 cat $ORIG/wrappers/msvcenv.sh \
 | sed 's/MSVCVER=.*/MSVCVER='$MSVCVER/ \
 | sed 's/SDKVER=.*/SDKVER='$SDKVER/ \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,14 @@ if (WIN32)
 endif()
 add_executable(hello ${hello_SOURCES})
 
+if(23 IN_LIST CMAKE_CXX_COMPILER_IMPORT_STD) # Since cmake 3.30
+    add_executable(hello-cxx23 hello.cpp)
+    target_compile_features(hello-cxx23 PUBLIC cxx_std_23)
+    set_target_properties(hello-cxx23 PROPERTIES
+        CXX_SCAN_FOR_MODULES ON
+        CXX_MODULE_STD ON
+    )
+endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND DEFINED MSVCDIR)
     add_library(cxxmodules STATIC "${MSVCDIR}/modules/std.ixx")

--- a/test/hello.cpp
+++ b/test/hello.cpp
@@ -1,0 +1,6 @@
+import std;
+
+int main()
+{
+    std::println("{}", "Hello world!");
+}

--- a/test/test-cmake.sh
+++ b/test/test-cmake.sh
@@ -41,9 +41,7 @@ EXEC "" ninja -v
 
 # Rerun ninja to make sure that dependencies aren't broken.
 EXEC ninja-rerun ninja -d explain -v
-DIFF ninja-rerun.err - <<EOF
-EOF
-DIFF ninja-rerun.out - <<EOF
+DIFF ninja-rerun.out - <<EOF || cat ninja-rerun.err
 ninja: no work to do.
 EOF
 


### PR DESCRIPTION
https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9337
The coming cmake 3.30 supports `import std` for clang and MSVC.

For MSVC, it need to locate `modules.json` which is in `${VCToolsInstallDir}/modules` (`VCToolsInstallDir = VC/Tools/MSVC/$VER`). https://gitlab.kitware.com/cmake/cmake/-/blob/ca449572ef8b1c6066e88879795900aea9727834/Modules/Compiler/MSVC-CXX-CXXImportStd.cmake#L2-11
```cmake
  find_file(_msvc_modules_json_file
    NAME modules.json
    HINTS
      "$ENV{VCToolsInstallDir}/modules"
    PATHS
      "$ENV{INCLUDE}"
      "${CMAKE_CXX_COMPILER}/../../.."
    PATH_SUFFIXES
      ../modules
    NO_CACHE)
```

To support `import std` without those environment variables presets, the specific directory layout is required. There are two ways going on:
1. Copy `${VCToolsInstallDir}/modules/*` to installation root. There are only 3 files in the `modules` folder: `modules.json`, `std.ixx` and `std.compat.ixx`. So I think it is acceptable.
2. Create symlink `modules` under installation root to `${VCToolsInstallDir}/modules`. This results in a different layout compared to the original MSVC tools layout.

VCToolsInstallDir layout:
  ```
  ${VCToolsInstallDir}/bin/Hostx64/x64/cl.exe
  ${VCToolsInstallDir}/modules/modules.json
  ```
Proposed msvc-wine installation layout:
  ```
  ${root}/bin/x64/cl.exe
  ${root}/modules/modules.json
  ```

This requires to add `"${CMAKE_CXX_COMPILER}/../.."` to above cmake code block. I prefer this way. If we agree, I am going to send a MR to CMake. But if they reject, we have to go with 1.

The test is not enabled currently since the new feature is experimental and is gated by `CMAKE_EXPERIMENTAL_CXX_IMPORT_STD` which is a UUID string and may be updated time to time, the value is documented at https://gitlab.kitware.com/cmake/cmake/-/blob/ca449572ef8b1c6066e88879795900aea9727834/Help/dev/experimental.rst.

