### PR TITLE
WIP: Add options for skipping downloading tools targeting ARM/ARM64, and for skipping ATL and DIA SDK

### DIFF
--- a/vsdownload.py
+++ b/vsdownload.py
@@ -54,6 +54,9 @@ def getArgsParser():
     parser.add_argument("--keep-unpack", const=True, action="store_const", help="Keep the unpacked files that aren't otherwise selected as needed output")
     parser.add_argument("--msvc-version", metavar="version", help="Install a specific MSVC toolchain version")
     parser.add_argument("--sdk-version", metavar="version", help="Install a specific Windows SDK version")
+    parser.add_argument("--architecture", metavar="arch", help="Target architecture to include (x86, x64, arm, arm64)", nargs="*")
+    parser.add_argument("--skip-atl", const=True, action="store_const", help="Skip installing the ATL headers")
+    parser.add_argument("--skip-diasdk", const=True, action="store_const", help="Skip installing the DIA SDK")
     parser.add_argument("--with-wdk-installers", metavar="dir", help="Install Windows Driver Kit using the provided MSI installers")
     return parser
 
@@ -63,10 +66,13 @@ def setPackageSelectionMSVC16(args, packages, userversion, sdk, toolversion, def
             sdkpkg = "Win11SDK_" + sdk
         else:
             sdkpkg = "Win10SDK_" + sdk
-        extraarchs = ["ARM", "ARM64"]
-        args.package.extend([sdkpkg, "Microsoft.VisualStudio.Component.VC." + toolversion + ".x86.x64", "Microsoft.VisualStudio.Component.VC." + toolversion + ".ATL"])
-        for arch in extraarchs:
-            args.package.extend(["Microsoft.VisualStudio.Component.VC." + toolversion + "." + arch, "Microsoft.VisualStudio.Component.VC." + toolversion + ".ATL." + arch])
+        args.package.extend([sdkpkg, "Microsoft.VisualStudio.Component.VC." + toolversion + ".x86.x64"])
+        if not args.skip_atl:
+            args.package.extend(["Microsoft.VisualStudio.Component.VC." + toolversion + ".ATL"])
+        for arch in args.extraarchs:
+            args.package.extend(["Microsoft.VisualStudio.Component.VC." + toolversion + "." + arch])
+            if not args.skip_atl:
+                args.package.extend(["Microsoft.VisualStudio.Component.VC." + toolversion + ".ATL." + arch])
     else:
         # Options for toolchains for specific versions. The latest version in
         # each manifest isn't available as a pinned version though, so if that
@@ -85,12 +91,24 @@ def setPackageSelectionMSVC15(args, packages, userversion, sdk, toolversion, def
         args.package.extend(defaultPackages)
 
 def setPackageSelection(args, packages):
+    if not args.architecture:
+        args.architecture = ["x86", "x64", "arm", "arm64"]
+    extraarchs = []
+    if "arm" in args.architecture:
+        extraarchs.extend(["ARM"])
+    if "arm64" in args.architecture:
+        extraarchs.extend(["ARM64"])
+    args.extraarchs = extraarchs
+
     # If no packages are selected, install these versionless packages, which
     # gives the latest/recommended version for the current manifest.
-    extraarchs = ["ARM", "ARM64"]
-    defaultPackages = ["Microsoft.VisualStudio.Workload.VCTools", "Microsoft.VisualStudio.Component.VC.ATL"]
+    defaultPackages = ["Microsoft.VisualStudio.Workload.VCTools"]
+    if not args.skip_atl:
+        defaultPackages.extend(["Microsoft.VisualStudio.Component.VC.ATL"])
     for arch in extraarchs:
-        defaultPackages.extend(["Microsoft.VisualStudio.Component.VC.Tools." + arch, "Microsoft.VisualStudio.Component.VC.ATL." + arch])
+        defaultPackages.extend(["Microsoft.VisualStudio.Component.VC.Tools." + arch])
+        if not args.skip_atl:
+            defaultPackages.extend(["Microsoft.VisualStudio.Component.VC.ATL." + arch])
 
     # Note, that in the manifest for MSVC version X.Y, only version X.Y-1
     # exists with a package name like "Microsoft.VisualStudio.Component.VC."
@@ -630,7 +648,10 @@ def moveVCSDK(unpack, dest):
     # The DIA SDK isn't necessary for normal use, but can be used when e.g.
     # compiling LLVM.
     # MSBuild is the standard VC build tool.
-    for extraDir in "DIA SDK", "MSBuild":
+    dirs = ["MSBuild"]
+    if not args.skip_diasdk:
+        dirs.extend(["DIA SDK"])
+    for extraDir in dirs:
         mergeTrees(os.path.join(unpack, extraDir), os.path.join(dest, extraDir))
 
 if __name__ == "__main__":

--- a/vsdownload.py
+++ b/vsdownload.py
@@ -63,7 +63,10 @@ def setPackageSelectionMSVC16(args, packages, userversion, sdk, toolversion, def
             sdkpkg = "Win11SDK_" + sdk
         else:
             sdkpkg = "Win10SDK_" + sdk
-        args.package.extend([sdkpkg, "Microsoft.VisualStudio.Component.VC." + toolversion + ".x86.x64", "Microsoft.VisualStudio.Component.VC." + toolversion + ".ARM", "Microsoft.VisualStudio.Component.VC." + toolversion + ".ARM64"])
+        extraarchs = ["ARM", "ARM64"]
+        args.package.extend([sdkpkg, "Microsoft.VisualStudio.Component.VC." + toolversion + ".x86.x64", "Microsoft.VisualStudio.Component.VC." + toolversion + ".ATL"])
+        for arch in extraarchs:
+            args.package.extend(["Microsoft.VisualStudio.Component.VC." + toolversion + "." + arch, "Microsoft.VisualStudio.Component.VC." + toolversion + ".ATL." + arch])
     else:
         # Options for toolchains for specific versions. The latest version in
         # each manifest isn't available as a pinned version though, so if that
@@ -84,7 +87,10 @@ def setPackageSelectionMSVC15(args, packages, userversion, sdk, toolversion, def
 def setPackageSelection(args, packages):
     # If no packages are selected, install these versionless packages, which
     # gives the latest/recommended version for the current manifest.
-    defaultPackages = ["Microsoft.VisualStudio.Workload.VCTools", "Microsoft.VisualStudio.Component.VC.Tools.ARM", "Microsoft.VisualStudio.Component.VC.Tools.ARM64"]
+    extraarchs = ["ARM", "ARM64"]
+    defaultPackages = ["Microsoft.VisualStudio.Workload.VCTools", "Microsoft.VisualStudio.Component.VC.ATL"]
+    for arch in extraarchs:
+        defaultPackages.extend(["Microsoft.VisualStudio.Component.VC.Tools." + arch, "Microsoft.VisualStudio.Component.VC.ATL." + arch])
 
     # Note, that in the manifest for MSVC version X.Y, only version X.Y-1
     # exists with a package name like "Microsoft.VisualStudio.Component.VC."

--- a/wrappers/msvcenv.sh
+++ b/wrappers/msvcenv.sh
@@ -34,8 +34,8 @@ SDKLIB="$SDKBASE\\lib\\$SDKVER"
 BINDIR=$BASE_UNIX/vc/tools/msvc/$MSVCVER/bin/Hostx64/$ARCH
 SDKBINDIR=$BASE_UNIX/$SDK_UNIX/bin/$SDKVER/x64
 MSBUILDBINDIR=$BASE_UNIX/MSBuild/Current/Bin/amd64
-export INCLUDE="$MSVCDIR\\include;$SDKINCLUDE\\shared;$SDKINCLUDE\\ucrt;$SDKINCLUDE\\um;$SDKINCLUDE\\winrt;$SDKINCLUDE\\km"
-export LIB="$MSVCDIR\\lib\\$ARCH;$SDKLIB\\ucrt\\$ARCH;$SDKLIB\\um\\$ARCH;$SDKLIB\\km\\$ARCH"
+export INCLUDE="$MSVCDIR\\atlmfc\\include;$MSVCDIR\\include;$SDKINCLUDE\\shared;$SDKINCLUDE\\ucrt;$SDKINCLUDE\\um;$SDKINCLUDE\\winrt;$SDKINCLUDE\\km"
+export LIB="$MSVCDIR\\atlmfc\\lib\\$ARCH;$MSVCDIR\\lib\\$ARCH;$SDKLIB\\ucrt\\$ARCH;$SDKLIB\\um\\$ARCH;$SDKLIB\\km\\$ARCH"
 export LIBPATH="$LIB"
 # "$MSVCDIR\\bin\\Hostx64\\x64" is included in PATH for DLLs.
 export WINEPATH="${BINDIR//\//\\};${SDKBINDIR//\//\\};$MSVCDIR\\bin\\Hostx64\\x64"


### PR DESCRIPTION
This goes on top of #143.

This works, but is quite primitive. If someone wants to pick this PR up and develop it further, that would be very much appreciated! (CC @huangqinjin)

I wanted to make it possible to skip downloading architectures, and/or extra libraries that you don't need. (Although ATL seems very small so it doesn't make much of a difference in any way whether we include it or not.)

I tried to make this general enough that you'd be able to say e.g. that you only want to target e.g. x86 and x64, and thus not adding the extra e.g. `*.ARM64` package selections. But if one only wants a compiler to target ARM but not x86/x64 at all, I think we'd need to manually select some more packages, at least for the latest version (when not selecting a version with `--msvc-version`).

As an extra, if one has skipped installing ARM/ARM64 files, we could also remove a lot of large libraries under WinSDK, but I didn't implement that yet.