### PR TITLE
vsdownload: Filter packages based on their arch information

### DIFF
--- a/vsdownload.py
+++ b/vsdownload.py
@@ -303,6 +303,13 @@ def matchPackageHostArch(p, host):
         if "host" + a in id:
             return a == host
 
+    for k in ["chip", "machineArch", "productArch"]:
+        a = p.get(k, "neutral").lower()
+        if a == "neutral":
+            continue
+        if a != host:
+            return False
+
     return True
 
 def printDepends(packages, target, constraints, indent, args):


### PR DESCRIPTION
Depends on #148.

#### Match host arch with `chip`, `machineArch` and `productArch`.
[PR #148](https://github.com/mstorsjo/msvc-wine/actions/runs/11198692222/job/31130172974?pr=148#step:4:49)
```
Selected 475 packages, for a total download size of 2.7 GB, install size of 8.5 GB
```

[PR #149 matching host arch exactly](https://github.com/mstorsjo/msvc-wine/actions/runs/11258538861/job/31305372957?pr=149)
```
Selected 449 packages, for a total download size of 2.5 GB, install size of 8.2 GB
```

**EDIT**: We go *matching host arch exactly*.

~~[PR #149](https://github.com/mstorsjo/msvc-wine/actions/runs/11202379694/job/31138414515?pr=149#step:4:49)~~

~~Selected 463 packages, for a total download size of 2.6 GB, install size of 8.3 GB~~

~~Current implementation apply the knownledge that~~
1. x64 host can run x86 binaries
1. arm64 host can run x86/x64 binaries

Otherwise some packages will be incomplete. E.g. package `Microsoft.VisualStudio.Debugger.Remote` on ARM64:
```shell
./vsdownload.py --accept-license --host-arch arm64 --print-deps-tree Microsoft.VisualStudio.Debugger.Remote

Microsoft.VisualStudio.Debugger.Remote
  Microsoft.VisualStudio.Debugger.Remote.Resources (chip.x64)
    Microsoft.VisualStudio.Debugger.Remote.Resources (chip.x86)
  Microsoft.VisualStudio.Debugger.Remote (chip.x86)
    Microsoft.VisualStudio.Debugger.Remote.Resources (chip.x86)
    Microsoft.VisualStudio.Debugger.Concord.Remote (chip.x86)
      Microsoft.VisualStudio.Debugger.Concord.Remote.Resources (chip.x86)
    Microsoft.VisualStudio.Debugger.Remote.DbgHelp.Win8 (chip.x86)
    Microsoft.VisualStudio.Debugger.Remote.ARM64
      Microsoft.VisualStudio.Debugger.Remote.Resources.ARM64
      Microsoft.VisualStudio.Debugger.Remote.ARM (machineArch.ARM64)
        Microsoft.VisualStudio.Debugger.Remote.Resources.ARM
        Microsoft.VisualStudio.Debugger.Concord.Remote.ARM (machineArch.ARM64)
          Microsoft.VisualStudio.Debugger.Concord.Remote.Resources.ARM
      Microsoft.VisualStudio.Debugger.Concord.Remote.ARM64 (machineArch.ARM64)
        Microsoft.VisualStudio.Debugger.Concord.Remote.Resources.ARM64
  Microsoft.VisualStudio.Debugger.Remote.DbgHelp.Win8 (chip.x64)
  Microsoft.VisualStudio.Debugger.Concord.Remote (chip.x64)
    Microsoft.VisualStudio.Debugger.Concord.Remote.Resources
```

But I think *matching host arch exactly* is also acceptable, and user need to specify `Microsoft.VisualStudio.Debugger.Remote.ARM64` instead of `Microsoft.VisualStudio.Debugger.Remote`.

