### PR TITLE
test: Disable testing vcpkg's PDB installation function

### DIFF
--- a/test/test-vcpkg.sh
+++ b/test/test-vcpkg.sh
@@ -33,7 +33,7 @@ EOF
 
 # Install dependencies with classic mode.
 EXEC "" vcpkg install sqlite3:$ARCH-windows --overlay-triplets=.
-EXEC "" file -E $VCPKG_ROOT/installed/$ARCH-windows/{,debug/}bin/sqlite3.{dll,pdb}
+EXEC "" file -E $VCPKG_ROOT/installed/$ARCH-windows/{,debug/}bin/sqlite3.dll
 
 # Create source files.
 cat >main.c <<EOF
@@ -107,7 +107,7 @@ EOF
 
 # Install dependencies with manifest mode.
 EXEC "" cmake -B b "${CMAKE_ARGS[@]}"
-EXEC "" file -E b/vcpkg_installed/$ARCH-windows/{,debug/}bin/sqlite3.{dll,pdb}
+EXEC "" file -E b/vcpkg_installed/$ARCH-windows/{,debug/}bin/sqlite3.dll
 
 EXEC "" cmake --build b --config Debug -- -v
 EXEC "" cmake --build b --config Release -- -v


### PR DESCRIPTION
Upstream commit https://github.com/microsoft/vcpkg/commit/6dbc951463b07484d165415667a8f65feda7fbf4 broke PDB installation on non-Windows.