### PR TITLE
vsdownload: Use id in dependencies if exists

### DIFF
--- a/vsdownload.py
+++ b/vsdownload.py
@@ -345,6 +345,7 @@ def printDepends(packages, target, constraints, indent, args):
     for target, constraints in p.get("dependencies", {}).items():
         if not isinstance(constraints, dict):
             constraints = { "version": constraints }
+        target = constraints.get("id", target)
         printDepends(packages, target, constraints, indent + "  ", args)
 
 def printReverseDepends(packages, target, deptype, indent, args):
@@ -396,6 +397,7 @@ def aggregateDepends(packages, included, target, constraints, args):
     for target, constraints in p.get("dependencies", {}).items():
         if not isinstance(constraints, dict):
             constraints = { "version": constraints }
+        target = constraints.get("id", target)
         deptype = constraints.get("type")
         if deptype == "Optional" and not args.include_optional:
             continue


### PR DESCRIPTION
Observed that starting with VS 17.12, package `Microsoft.VisualStudio.PackageGroup.VsDevCmd` is missing
https://github.com/mstorsjo/msvc-wine/actions/runs/11948558852/job/33306358321#step:4:42, compared to VS 17.11
https://github.com/mstorsjo/msvc-wine/actions/runs/11427400934/job/31791489553#step:4:39.

Checked dependencies with their manifests,
- 17.11:
```
Microsoft.VisualStudio.Workload.VCTools
  Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core
    Microsoft.VisualStudio.PackageGroup.VC.CoreIDE.Reduced
      Microsoft.VisualStudio.PackageGroup.Core
        Microsoft.VisualStudio.PackageGroup.CoreEditor
          Microsoft.VisualStudio.PackageGroup.VsDevCmd
```

- 17.12:
```
Microsoft.VisualStudio.Workload.VCTools
  Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core
    Microsoft.VisualStudio.PackageGroup.VC.CoreIDE.Reduced
      Microsoft.VisualStudio.PackageGroup.Core
        Microsoft.VisualStudio.PackageGroup.CoreEditor
          Microsoft.VisualStudio.PackageGroup.VsDevCmd_-137610554 (NotFound)
```

And the dependency constraint contains a `id` field. So I believe it should be used, though I don't know what the numbers after the package name mean.
```json
{
  "id": "Microsoft.VisualStudio.PackageGroup.CoreEditor",
  "dependencies": {
    "Microsoft.VisualStudio.PackageGroup.VsDevCmd_-137610554": {
      "id": "Microsoft.VisualStudio.PackageGroup.VsDevCmd",
      "version": "[17.0,18.0)",
    }
  }
}
```
