### PR TITLE
vsdownload: Workaround for inconsistent MSBuild folder casing when extracting packages

### DIFF
--- a/vsdownload.py
+++ b/vsdownload.py
@@ -640,6 +640,9 @@ def unpackWin10WDK(src, dest):
 
 def extractPackages(selected, cache, dest):
     makedirs(dest)
+    # The path name casing is not consistent across packages, or even within a single package.
+    # Manually create top-level folders before extracting packages to ensure the desired casing.
+    makedirs(os.path.join(dest, "MSBuild"))
     for p in selected:
         type = p["type"]
         dir = os.path.join(cache, getPackageKey(p))


### PR DESCRIPTION
Observed that `MSBuild` casing is not consistent, e.g. package `Microsoft.VisualStudio.StaticAnalysis.auxil` contains
```
Contents/Msbuild/Microsoft/VC/v170/fxcop.xml
Contents/MSBuild/Microsoft/VisualStudio/v17.0/CodeAnalysis/fxcoptask.dll
```

What we get finally depends on the extracting order of packages, we may get `MSBuild`, `Msbuild` or even both. This workaround make sure we get `MSBuild`, because `mergeTrees` will merge any casing into the existing `MSBuild` folder.