### PR TITLE
Revert "test: Disable testing vcpkg's PDB installation function"

### DIFF
--- a/test/test-vcpkg.sh
+++ b/test/test-vcpkg.sh
@@ -33,7 +33,7 @@ EOF
 
 # Install dependencies with classic mode.
 EXEC "" vcpkg install sqlite3:$ARCH-windows --overlay-triplets=.
-EXEC "" file -E $VCPKG_ROOT/installed/$ARCH-windows/{,debug/}bin/sqlite3.dll
+EXEC "" file -E $VCPKG_ROOT/installed/$ARCH-windows/{,debug/}bin/sqlite3.{dll,pdb}
 
 # Create source files.
 cat >main.c <<EOF
@@ -107,7 +107,7 @@ EOF
 
 # Install dependencies with manifest mode.
 EXEC "" cmake -B b "${CMAKE_ARGS[@]}"
-EXEC "" file -E b/vcpkg_installed/$ARCH-windows/{,debug/}bin/sqlite3.dll
+EXEC "" file -E b/vcpkg_installed/$ARCH-windows/{,debug/}bin/sqlite3.{dll,pdb}
 
 EXEC "" cmake --build b --config Debug -- -v
 EXEC "" cmake --build b --config Release -- -v


### PR DESCRIPTION
This reverts commit e3c35c04379ab641dc72cc09bbe3f9ef2d74d44c.

Upstream commit https://github.com/microsoft/vcpkg/commit/6ae3ccc87c3617b06ac1578ef9b9944f1bb8a373 made PDB installation on non-Windows work again.