### PR TITLE
vsdownload: Error out if the requested SDK version isn't found

### DIFF
--- a/vsdownload.py
+++ b/vsdownload.py
@@ -22,6 +22,7 @@ import os
 import multiprocessing.pool
 import json
 import platform
+import re
 import shutil
 import socket
 import subprocess
@@ -167,14 +168,26 @@ def setPackageSelection(args, packages):
         args.package = defaultPackages
 
     if args.sdk_version != None:
+        found = False
+        versions = []
         for key in packages:
             if key.startswith("win10sdk") or key.startswith("win11sdk"):
                 base = key[0:8]
+                version = key[9:]
+                if re.match(r'\d+\.\d+\.\d+', version):
+                    versions += [version]
                 sdkname = base + "_" + args.sdk_version
                 if key == sdkname:
+                    found = True
                     args.package.append(key)
                 else:
                     args.ignore.append(key)
+        if not found:
+            print("WinSDK version " + args.sdk_version + " not found")
+            print("Available versions:")
+            for v in sorted(versions):
+                print("    " + v)
+            sys.exit(1)
 
 def lowercaseIgnores(args):
     ignore = []

--- a/vsdownload.py
+++ b/vsdownload.py
@@ -175,7 +175,6 @@ def setPackageSelection(args, packages):
                     args.package.append(key)
                 else:
                     args.ignore.append(key)
-        p = packages[key][0]
 
 def lowercaseIgnores(args):
     ignore = []


### PR DESCRIPTION
Also list the potential alternatives.

Also remove a leftover unused line of code, that seems to have been included by accident in the commit that added this feature, in 23d7c7b817ea21deba6d15c76ad655ee31d0e2e6.

CC @huangqinjin 