### PR TITLE
install: Make ATL headers use consistent lower case includes of other headers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,6 +73,11 @@ cd ..
 # and the call to fixinclude lowercases those references.
 "$ORIG"/lowercase -symlink include
 "$ORIG"/fixinclude include
+if [ -d "atlmfc/include" ]; then
+    # The ATL headers are lowercased themselves, but they refer to
+    # WinSDK headers with mixed casing.
+    "$ORIG"/fixinclude "atlmfc/include"
+fi
 cd bin
 # vctip.exe is known to cause problems at some times; just remove it.
 # See https://bugs.chromium.org/p/chromium/issues/detail?id=735226 and


### PR DESCRIPTION
This makes clang-cl use of e.g. atlbase.h work on case sensitive file systems (as atlbase.h originally includes OleCtl.h), and makes MSVC use of atlbase.h produce dependency files that don't require files to be rebuilt every time.

This should fix #167.

CC @vid512