### PR TITLE
github: Update `wine-mono` to v8.1.0 on Ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,10 @@ env:
 
 jobs:
   test-msvc-wine-linux:
-    runs-on: ubuntu-latest
+    # Using a pinned version of Ubuntu here; this determines the version of
+    # Wine that gets installed - the version of wine-mono that is installed
+    # below depends on the host version of Wine.
+    runs-on: ubuntu-24.04
     steps:
       - name: Install prerequisites
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,7 @@ env:
 
 jobs:
   test-msvc-wine-linux:
-    # wdk-download.sh doesn't work on ubuntu 24.04 (ubuntu-latest)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install prerequisites
         run: |
@@ -18,8 +17,9 @@ jobs:
           sudo apt-get install wine64 wine32 python3 msitools ca-certificates cmake ninja-build winbind meson
           WINE=$(command -v wine64 || command -v wine || false)
           $WINE wineboot
-          curl -s -L -O https://github.com/madewokherd/wine-mono/releases/download/wine-mono-5.1.1/wine-mono-5.1.1-x86.msi
-          $WINE msiexec /i wine-mono-5.1.1-x86.msi
+          # Check https://gitlab.winehq.org/wine/wine/-/wikis/Wine-Mono#versions before updating the WINE package!
+          curl -s -L -O https://github.com/madewokherd/wine-mono/releases/download/wine-mono-8.1.0/wine-mono-8.1.0-x86.msi
+          $WINE msiexec /i wine-mono-8.1.0-x86.msi
       - uses: actions/checkout@v4
       - name: Download MSVC
         run: |


### PR DESCRIPTION
Switch the Linux CI workflow back to `ubuntu-latest`.

Update `wine-mono` to version 8.1.0 as instructed in
https://gitlab.winehq.org/wine/wine/-/wikis/Wine-Mono#versions

Resolves #172