### PR TITLE
Revert "github: Install Wine Mono 9.0 for macOS"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,6 @@ jobs:
           brew install wine-stable msitools cmake ninja meson
           WINE=$(command -v wine64 || command -v wine || false)
           $WINE wineboot
-          curl -s -L -O https://github.com/madewokherd/wine-mono/releases/download/wine-mono-9.0.0/wine-mono-9.0.0-x86.msi
-          $WINE msiexec /i wine-mono-9.0.0-x86.msi
       - uses: actions/checkout@v4
       - name: Download MSVC
         run: |


### PR DESCRIPTION
This reverts commit a40dd807ceaa189783766c447ea2c67b0d68f588.

Wine 10.0 bundled with Wine Mono 9.4.0, is now available on github macOS runners.