### PR TITLE
Revert "Revert "github: Install Wine Mono 9.0 for macOS""

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
           brew install wine-stable msitools cmake ninja meson
           WINE=$(command -v wine64 || command -v wine || false)
           $WINE wineboot
+          curl -s -L -O https://github.com/madewokherd/wine-mono/releases/download/wine-mono-9.0.0/wine-mono-9.0.0-x86.msi
+          $WINE msiexec /i wine-mono-9.0.0-x86.msi
       - uses: actions/checkout@v4
       - name: Download MSVC
         run: |


### PR DESCRIPTION
Reverts #182 due to macOS runners upgrade got reverted by https://github.com/actions/runner-images/pull/11700.