### PR TITLE
chore: make scripts more portable with /usr/bin/env

### DIFF
--- a/fixinclude
+++ b/fixinclude
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Copyright (c) 2019 Martin Storsjo
 #

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Copyright (c) 2019 Martin Storsjo
 #

--- a/lowercase
+++ b/lowercase
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Copyright (c) 2019 Martin Storsjo
 #

--- a/msvcenv-native.sh
+++ b/msvcenv-native.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 #
 # Copyright (c) 2019 Martin Storsjo
 #
@@ -33,9 +33,9 @@ else
     if [ ! -f "$ENV" ]; then
         echo $ENV doesn\'t exist
     else
-        export INCLUDE="$(bash -c ". $ENV && /bin/echo \"\$INCLUDE\"" | sed s/z://g | sed 's/\\/\//g')"
-        export LIB="$(bash -c ". $ENV && /bin/echo \"\$LIB\"" | sed s/z://g | sed 's/\\/\//g')"
-        MSVCARCH="$(bash -c ". $ENV && /bin/echo \"\$ARCH\"")"
+        export INCLUDE="$(bash -c ". $ENV && /usr/bin/env echo \"\$INCLUDE\"" | sed s/z://g | sed 's/\\/\//g')"
+        export LIB="$(bash -c ". $ENV && /usr/bin/env echo \"\$LIB\"" | sed s/z://g | sed 's/\\/\//g')"
+        MSVCARCH="$(bash -c ". $ENV && /usr/bin/env echo \"\$ARCH\"")"
         case $MSVCARCH in
         x86) TARGET_ARCH=i686 ;;
         x64) TARGET_ARCH=x86_64 ;;

--- a/test/test-asm.sh
+++ b/test/test-asm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2023 Martin Storsjo
 #

--- a/test/test-cl.sh
+++ b/test/test-cl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2023 Huang Qinjin
 #

--- a/test/test-clang-cl-cmds.sh
+++ b/test/test-clang-cl-cmds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2023 Martin Storsjo
 #

--- a/test/test-clang-cl.sh
+++ b/test/test-clang-cl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2023 Martin Storsjo
 #

--- a/test/test-cmake-clang-cl.sh
+++ b/test/test-cmake-clang-cl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2023 Martin Storsjo
 #

--- a/test/test-cmake.sh
+++ b/test/test-cmake.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2023 Huang Qinjin
 #

--- a/test/test-dumpbin.sh
+++ b/test/test-dumpbin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2023 Huang Qinjin
 #

--- a/test/test-mc.sh
+++ b/test/test-mc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2024 Mark Harmstone
 #

--- a/test/test-meson.sh
+++ b/test/test-meson.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2023 Martin Storsjo
 #

--- a/test/test-midl.sh
+++ b/test/test-midl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2023 Martin Storsjo
 #

--- a/test/test-msbuild.sh
+++ b/test/test-msbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2024 Sergey Kvachonok
 #

--- a/test/test-mt.sh
+++ b/test/test-mt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2023 Huang Qinjin
 #

--- a/test/test-vcpkg.sh
+++ b/test/test-vcpkg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2024 Huang Qinjin
 #

--- a/test/test-wdk-msbuild.sh
+++ b/test/test-wdk-msbuild.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2024 Sergey Kvachonok
 #

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2023 Huang Qinjin
 #

--- a/vsdownload.py
+++ b/vsdownload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright (c) 2019 Martin Storsjo
 #

--- a/wdk-download.sh
+++ b/wdk-download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2024 Sergey Kvachonok
 #

--- a/wrappers/armasm
+++ b/wrappers/armasm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/armasm64
+++ b/wrappers/armasm64
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/cl
+++ b/wrappers/cl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/cmd
+++ b/wrappers/cmd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/dumpbin
+++ b/wrappers/dumpbin
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/findstr
+++ b/wrappers/findstr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2024 Huang Qinjin
 #

--- a/wrappers/lib
+++ b/wrappers/lib
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/link
+++ b/wrappers/link
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/mc
+++ b/wrappers/mc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/midl
+++ b/wrappers/midl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/ml
+++ b/wrappers/ml
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/ml64
+++ b/wrappers/ml64
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/msbuild
+++ b/wrappers/msbuild
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2024 Sergey Kvachonok
 #

--- a/wrappers/msvcenv.sh
+++ b/wrappers/msvcenv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/mt
+++ b/wrappers/mt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/nmake
+++ b/wrappers/nmake
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/rc
+++ b/wrappers/rc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #

--- a/wrappers/wine-msvc.sh
+++ b/wrappers/wine-msvc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Martin Storsjo
 #


### PR DESCRIPTION
For example, it works on NixOS now:

```shell
$ nix-shell -p wineWow64Packages.stable python3 msitools clang.cc lld

impure (shell) $ ./vsdownload.py --dest ~/my_msvc
impure (shell) $ ./install.sh ~/my_msvc
impure (shell) $ BIN=~/my_msvc/bin/x64 . ./msvcenv-native.sh
impure (shell) $ clang++ --target=x86_64-windows-msvc hello.cc -fuse-ld=lld -o hello.exe
impure (shell) $ wine hello.exe
```
