### PR TITLE
vsdownload: Only download the right SDK for MSVC 16/17 with --msvc-version

### DIFF
--- a/vsdownload.py
+++ b/vsdownload.py
@@ -103,11 +103,8 @@ def setPackageSelectionMSVC16(args, packages, userversion, sdk, toolversion, def
             args.package.append("Microsoft.VisualStudio.Component.VC." + toolversion + ".ARM64")
             args.package.append("Microsoft.VisualStudio.Component.VC." + toolversion + ".ATL.ARM64")
 
-        if sdk.startswith("10.0.") and int(sdk[5:]) >= 22000:
-            sdkpkg = "Win11SDK_" + sdk
-        else:
-            sdkpkg = "Win10SDK_" + sdk
-        args.package.append(sdkpkg)
+        if args.sdk_version == None:
+            args.sdk_version = sdk
     else:
         # Options for toolchains for specific versions. The latest version in
         # each manifest isn't available as a pinned version though, so if that


### PR DESCRIPTION
Previously, we'd end up downloading both the default SDK from the manifest, and the SDK that was default for that version of MSVC.

Then install.sh would pick the latest SDK out of the ones installed, which wouldn't be the right choice when we explicitly wanted an older one.

If selecting an implicit default SDK via --msvc-version, set this as the option as if set via --sdk-version, which forces other SDKs to be ignored.