### PR TITLE
Make MSBuild work out of the box 

### DIFF
--- a/patches/MSBuild/Microsoft/VC/v170/ImportBefore/Default/msvc-wine.props
+++ b/patches/MSBuild/Microsoft/VC/v170/ImportBefore/Default/msvc-wine.props
@@ -1,0 +1,29 @@
+<!--
+ Copyright (c) 2024 Huang Qinjin
+
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(WindowsSdkDir_10)' == '' and (
+      '$(WindowsTargetPlatformVersion)' == '' or
+      '$(WindowsTargetPlatformVersion)' == '10.0' or
+      Exists('$(VSInstallRoot)\Windows Kits\10\Include\$(WindowsTargetPlatformVersion)\shared\sdkddkver.h'))">
+    <MsvcWine_WindowsSdkRoots>$(VSInstallRoot)</MsvcWine_WindowsSdkRoots>
+    <WindowsSdkDir_10>$(VSInstallRoot)\Windows Kits\10\</WindowsSdkDir_10>
+    <UniversalCRTSdkDir_10 Condition="'$(UniversalCRTSdkDir_10)' == ''">$(WindowsSdkDir_10)</UniversalCRTSdkDir_10>
+    <UCRTContentRoot Condition="'$(UCRTContentRoot)' == ''">$(WindowsSdkDir_10)</UCRTContentRoot>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PreferredToolArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'AMD64'">x64</PreferredToolArchitecture>
+  </PropertyGroup>
+</Project>

--- a/patches/MSBuild/Microsoft/VC/v170/Microsoft.Cpp.WindowsSDK.props.patch
+++ b/patches/MSBuild/Microsoft/VC/v170/Microsoft.Cpp.WindowsSDK.props.patch
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2024 Huang Qinjin
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+[PATCH] Look for the latest Windows SDK in the VS installation root in addition to the registry.
+
+diff --git a/MSBuild/Microsoft/VC/v170/Microsoft.Cpp.WindowsSDK.props b/MSBuild/Microsoft/VC/v170/Microsoft.Cpp.WindowsSDK.props
+--- a/MSBuild/Microsoft/VC/v170/Microsoft.Cpp.WindowsSDK.props
++++ b/MSBuild/Microsoft/VC/v170/Microsoft.Cpp.WindowsSDK.props
+@@ -119,7 +119,7 @@ Copyright (C) Microsoft Corporation. All rights reserved.
+     <SDKVersion Condition="'$(SDKVersion)' == ''">10.0</SDKVersion>
+     <SDKDisplayName Condition="'$(SDKDisplayName)' == ''">Windows 10</SDKDisplayName>
+ 
+-    <_LatestWindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion($(SDKIdentifier), $(SDKVersion)))</_LatestWindowsTargetPlatformVersion>
++    <_LatestWindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion($(SDKIdentifier), $(SDKVersion), $(MsvcWine_WindowsSdkRoots.Split(';', StringSplitOptions.RemoveEmptyEntries))))</_LatestWindowsTargetPlatformVersion>
+     <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == '' and '$(_LatestWindowsTargetPlatformVersion)' != ''">10.0</WindowsTargetPlatformVersion>
+   </PropertyGroup>
+ 

--- a/test/test-msbuild.ps1
+++ b/test/test-msbuild.ps1
@@ -1,0 +1,72 @@
+#
+# Copyright (c) 2024 Huang Qinjin
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+. $PSScriptRoot/test.ps1 @args
+
+function realpath($p) {
+    $item = Get-Item -LiteralPath $p
+    $target = $item.Target
+    $p = if ($target) { "$target" } else { $item.FullName }
+    return $p.TrimEnd('\/')
+}
+
+# Verify that the compiler uses header files under the installation root.
+function VerifyIncludes($file) {
+    Select-String 'Note: including file:(.*)' -Path $file |
+    ForEach-Object { $_.Matches[0].Groups[1].Value.Trim() } |
+    Sort-Object -Unique |
+    Where-Object { -not (realpath $_).StartsWith((realpath $Root)) } |
+    Out-File cl-showIncludes.bad -Encoding utf8
+    DIFF cl-showIncludes.bad -
+}
+
+$Platform = switch ($Arch) {
+    'x86' { 'Win32' }
+    default { $Arch }
+}
+
+$MSBuildArch = switch ($HostArch) {
+    'x86' { '' }
+    'x64' { 'amd64' }
+    default { $HostArch }
+}
+
+$MSBuild = [IO.Path]::Combine($Root, 'MSBuild', 'Current', 'Bin', $MSBuildArch, 'MSBuild.exe')
+
+$env:CL="/showIncludes"
+
+EXEC "" $MSBuild /v:q /consoleLoggerParameters:ShowCommandLine `
+    /fileLogger /fileLoggerParameters:Verbosity=minimal `
+    /p:Platform=$Platform /p:Configuration=Release `
+    /p:IntDir="${CWD}" /p:OutDir="${CWD}" `
+    /p:VcpkgEnabled=false `
+    "${TESTS}HelloWorld.vcxproj"
+
+VerifyIncludes msbuild.log
+
+# CMake 3.23 and later supports portable VS instances, which are not known to the Visual Studio Installer.
+# CMake 3.31 or later is required if Visual Studio Installer is not installed on the system.
+EXEC "" cmake -DCMAKE_GENERATOR_INSTANCE="$Root,version=17.0.0.0" `
+    -G "Visual Studio 17 2022" -A "$Platform,version=10.0" `
+    -S "$TESTS" -B a
+
+EXEC "" cmake --build a --config RelWithDebInfo '--' `
+    /v:q /consoleLoggerParameters:ShowCommandLine `
+    /fileLogger /fileLoggerParameters:Verbosity=minimal `
+    /p:VcpkgEnabled=false
+
+VerifyIncludes a/msbuild.log
+
+QUIT

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -172,6 +172,8 @@ foreach ($target in $TargetArchs) {
     if ($env:VCPKG_ROOT) {
         EXEC "" @PWSH test-vcpkg.ps1 @CommonArgs
     }
+
+    EXEC "" @PWSH test-msbuild.ps1 @CommonArgs
 }
 
 QUIT


### PR DESCRIPTION
MSBuild now works without any environment presets or extra command line arguments.
The props importing hierarchy plus key properties setting of a vcxproj is shown below.

```
vcxproj
 <WindowsTargetPlatformVersion>
 Microsoft.Cpp.Default.props
  ImportBefore\Default\*.props
 Microsoft.Cpp.props
  Microsoft.Cpp.ToolsetLocation.props
   <PreferredToolArchitecture>
   Platforms\x64\Platform.props
    Microsoft.Cpp.Platform.props
     Platforms\x64\ImportBefore\*.props
     Platforms\x64\PlatformToolsets\v143\Toolset.props
      Platforms\x64\PlatformToolsets\v143\ImportBefore\*.props
      Microsoft.Cpp.MSVC.Toolset.x64.props
       Microsoft.Cpp.MSVC.Toolset.Common.props
        Microsoft.Cpp.WindowsSDK.props
         <WindowsSdkDir_10>
         <UniversalCRTSdkDir_10>
         <_LatestWindowsTargetPlatformVersion>
         <WindowsTargetPlatformVersion>
         $(UniversalCRTSdkDir)\DesignTime\CommonConfiguration\Neutral\ucrt.props
          <UCRTContentRoot>
          <TargetUniversalCRTVersion>
```