### PR TITLE
vsdownload: Add a language parameter

### DIFF
--- a/vsdownload.py
+++ b/vsdownload.py
@@ -88,6 +88,7 @@ def getArgsParser():
     parser.add_argument("--host-arch", metavar="arch", choices=["x86", "x64", "arm64"], help="Specify the host architecture of packages to install")
     parser.add_argument("--only-host", default=True, action=OptionalBoolean, help="Only download packages that match host arch")
     parser.add_argument("--skip-patch", action="store_true", help="Don't patch downloaded packages")
+    parser.add_argument("--language", metavar="xx[-YY]", default="en", help="Preferred language code for packages available in multiple languages (defaults to en)")
     return parser
 
 def setPackageSelectionMSVC16(args, packages, userversion, sdk, toolversion, defaultPackages):
@@ -336,13 +337,26 @@ def prioritizePackage(arch, a, b):
         if r != 0:
             return r
 
-    if "language" in a and "language" in b:
-        aeng = a["language"].lower().startswith("en-")
-        beng = b["language"].lower().startswith("en-")
-        if aeng and not beng:
-            return -1
-        if beng and not aeng:
-            return 1
+    lang = args.language.lower()
+    countrylang = "-" in lang
+    alangpriority = 0
+    blangpriority = 0
+    if "language" in a:
+        alang = a["language"].lower()
+        if (countrylang and alang == lang) or (not countrylang and alang.startswith(lang + "-")):
+            alangpriority = 2
+        elif alang.startswith("en-"):
+            alangpriority = 1
+    if "language" in b:
+        blang = b["language"].lower()
+        if (countrylang and blang == lang) or (not countrylang and blang.startswith(lang + "-")):
+            blangpriority = 2
+        elif blang.startswith("en-"):
+            blangpriority = 1
+    if alangpriority > blangpriority:
+        return -1
+    if alangpriority < blangpriority:
+        return 1
     return 0
 
 def getPackages(manifest, arch):


### PR DESCRIPTION
This PR allows to select the packages to download in a preferred language from the packages available in multiple languages.

The parameter value is an ISO language code "xx" or an ISO country-language code "xx-YY".

Examples:
```
--language fr
--language fr-FR
--language pt-BR
--language zh-CN
--language zh-TW
```
Currently, the available languages ​​are: cs-CZ, de-DE, en-US, es-ES, fr-FR, it-IT, ja-JP, ko-KR, pl-PL, pt-BR, ru-RU, tr-TR, zh-CN, zh-TW.

The packages are chosen based on their language in the following order of priority (highest priority first):
- Country-language "xx-YY" specified,  
or
Language "xx" specified; matches any country-language beginning with "xx-".
- "en".
- Other language.

Packages not containing language information are not affected.
The default value of the parameter is "en" (same behavior as currently).