### PR TITLE
vsdownload: Add missing `vcvarsall.bat` for `--with-devcmd`

### DIFF
--- a/vsdownload.py
+++ b/vsdownload.py
@@ -329,6 +329,7 @@ def setPackageSelection(args, packages):
     appendPackageSelection(args, args.with_dia, "Microsoft.VisualCpp.DIA.SDK")
     appendPackageSelection(args, args.with_msbuild, "Microsoft.Build")
     appendPackageSelection(args, args.with_msbuild, "Microsoft.Build.Dependencies")
+    appendPackageSelection(args, args.with_devcmd, "Microsoft.VisualCpp.Tools.Core.x86")
     appendPackageSelection(args, args.with_devcmd, "Microsoft.VisualStudio.VC.vcvars")
     appendPackageSelection(args, args.with_devcmd, "Microsoft.VisualStudio.PackageGroup.VsDevCmd")
 


### PR DESCRIPTION
The file didn't get installed If we don't install the latest MSVC, for example, if we only install Preview MSVC.

Arch specific files such as `vcvars64.bat` and `vcvars32.bat` are still missing, but they are just one-line wrapper of `vcvarsall.bat`.