### PR TITLE
Update GitHub Actions and Dockerfiles to Ubuntu 26.04, cache VS packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,23 @@ env:
   WDK_INSTALLER_URL: "https://go.microsoft.com/fwlink/?linkid=2307500"
 
 jobs:
+  populate-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Cache vsdownload packages
+        uses: actions/cache@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~/.cache/vsdownload
+          key: vsdownload
+      - name: Populate vsdownload cache
+        run: |
+          sudo apt-get update && sudo apt-get install -y python3 msitools
+          ./vsdownload.py --accept-license --only-download --cache ~/.cache/vsdownload
+
   test-msvc-wine-linux:
+    needs: populate-cache
     # Using a pinned version of Ubuntu here; this determines the version of
     # Wine that gets installed - the version of wine-mono that is installed
     # below depends on the host version of Wine.
@@ -24,11 +40,19 @@ jobs:
           curl -s -L -O https://github.com/wine-mono/wine-mono/releases/download/wine-mono-9.4.0/wine-mono-9.4.0-x86.msi
           $WINE msiexec /i wine-mono-9.4.0-x86.msi
       - uses: actions/checkout@v6
+      - name: Set up vsdownload cache
+        run: mkdir -p ~/.cache/vsdownload
+      - name: Cache vsdownload packages
+        uses: actions/cache/restore@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~/.cache/vsdownload
+          key: vsdownload
       - name: Download MSVC
         run: |
-          WDK_INSTALLERS=$(./wdk-download.sh --cache /var/tmp/msvc-wine "$WDK_INSTALLER_URL")
+          WDK_INSTALLERS=$(./wdk-download.sh --cache ~/.cache/vsdownload "$WDK_INSTALLER_URL")
           echo Downloaded WDK installers to $WDK_INSTALLERS
-          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache /var/tmp/msvc-wine --with-wdk-installers "$WDK_INSTALLERS"
+          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache ~/.cache/vsdownload --with-wdk-installers "$WDK_INSTALLERS"
           ./install.sh $(pwd)/msvc
       - name: Test using the installed tools
         run: |
@@ -37,6 +61,7 @@ jobs:
       # the installed files aren't redistributable!
 
   test-msvc-wine-linux-arm:
+    needs: populate-cache
     runs-on: ubuntu-26.04-arm
     # Use a custom base container for providing wine; the base Wine package
     # in Ubuntu 24.04 is broken on aarch64, see
@@ -52,9 +77,17 @@ jobs:
           WINE=$(command -v wine64 || command -v wine || false)
           $WINE wineboot
       - uses: actions/checkout@v6
+      - name: Set up vsdownload cache
+        run: mkdir -p ~/.cache/vsdownload
+      - name: Cache vsdownload packages
+        uses: actions/cache/restore@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~/.cache/vsdownload
+          key: vsdownload
       - name: Download MSVC
         run: |
-          ./vsdownload.py --accept-license --dest $(pwd)/msvc
+          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache ~/.cache/vsdownload
           ./install.sh $(pwd)/msvc
       - name: Test using the installed tools
         run: |
@@ -63,6 +96,7 @@ jobs:
       # the installed files aren't redistributable!
 
   test-msvc-wine-linux-arm-target-host-only:
+    needs: populate-cache
     runs-on: ubuntu-26.04-arm
     # Use a custom base container for providing wine; the base Wine package
     # in Ubuntu 24.04 is broken on aarch64, see
@@ -78,9 +112,17 @@ jobs:
           WINE=$(command -v wine64 || command -v wine || false)
           $WINE wineboot
       - uses: actions/checkout@v6
+      - name: Set up vsdownload cache
+        run: mkdir -p ~/.cache/vsdownload
+      - name: Cache vsdownload packages
+        uses: actions/cache/restore@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~/.cache/vsdownload
+          key: vsdownload
       - name: Download MSVC
         run: |
-          ./vsdownload.py --accept-license --architecture host --dest $(pwd)/msvc
+          ./vsdownload.py --accept-license --architecture host --dest $(pwd)/msvc --cache ~/.cache/vsdownload
           ./install.sh $(pwd)/msvc
       - name: Test using the installed tools
         run: |
@@ -89,6 +131,7 @@ jobs:
       # the installed files aren't redistributable!
 
   test-msvc-wine-macos:
+    needs: populate-cache
     runs-on: macos-latest
     steps:
       - name: Install prerequisites
@@ -97,9 +140,15 @@ jobs:
           WINE=$(command -v wine64 || command -v wine || false)
           $WINE wineboot
       - uses: actions/checkout@v6
+      - name: Cache vsdownload packages
+        uses: actions/cache/restore@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~/Library/Caches/vsdownload
+          key: vsdownload
       - name: Download MSVC
         run: |
-          ./vsdownload.py --accept-license --dest $(pwd)/msvc
+          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache ~/Library/Caches/vsdownload
           ./install.sh $(pwd)/msvc
       - name: Test using the installed tools
         run: |
@@ -108,6 +157,7 @@ jobs:
       # the installed files aren't redistributable!
 
   test-clang-lld:
+    needs: populate-cache
     # Ubuntu 22.04 comes with Clang/LLD 14; at least 13 is required for providing
     # __guard_eh_cont_table and __guard_eh_cont_count which are required with
     # MSVC 2019 16.8 or newer.
@@ -129,9 +179,17 @@ jobs:
               sudo ln -s /usr/bin/lld /usr/bin/lld-link
           fi
       - uses: actions/checkout@v6
+      - name: Set up vsdownload cache
+        run: mkdir -p ~/.cache/vsdownload
+      - name: Cache vsdownload packages
+        uses: actions/cache/restore@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~/.cache/vsdownload
+          key: vsdownload
       - name: Download MSVC
         run: |
-          ./vsdownload.py --accept-license --dest $(pwd)/msvc
+          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache ~/.cache/vsdownload
           ./install.sh $(pwd)/msvc
       - name: Test using the installed tools
         run: |
@@ -156,42 +214,64 @@ jobs:
       # the installed files aren't redistributable!
 
   test-vsdownload-windows:
+    needs: populate-cache
     runs-on: windows-latest
     steps:
       - name: Install prerequisites
         run: |
           choco upgrade --no-progress cmake
       - uses: actions/checkout@v6
+      - name: Cache vsdownload packages
+        uses: actions/cache/restore@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~\AppData\Local\vsdownload
+          key: vsdownload
       - name: Download MSVC
         run: |
-          python vsdownload.py --accept-license --dest c:/msvc
+          python vsdownload.py --accept-license --dest c:/msvc --cache "$env:LOCALAPPDATA\vsdownload"
       - name: Test using the installed tools
         run: |
           test\test.bat c:\msvc
 
   test-vsdownload-windows-arm:
+    needs: populate-cache
     runs-on: windows-11-arm
     steps:
       - uses: actions/checkout@v6
+      - name: Cache vsdownload packages
+        uses: actions/cache/restore@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~\AppData\Local\vsdownload
+          key: vsdownload
       - name: Download MSVC
         run: |
-          python vsdownload.py --accept-license --dest c:/msvc
+          python vsdownload.py --accept-license --dest c:/msvc --cache "$env:LOCALAPPDATA\vsdownload"
       - name: Test using the installed tools
         run: |
           test\test.bat c:\msvc
 
   test-vsdownload-windows-arm-target-host-only:
+    needs: populate-cache
     runs-on: windows-11-arm
     steps:
       - uses: actions/checkout@v6
+      - name: Cache vsdownload packages
+        uses: actions/cache/restore@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~\AppData\Local\vsdownload
+          key: vsdownload
       - name: Download MSVC
         run: |
-          python vsdownload.py --accept-license --architecture host --dest c:/msvc
+          python vsdownload.py --accept-license --architecture host --dest c:/msvc --cache "$env:LOCALAPPDATA\vsdownload"
       - name: Test using the installed tools
         run: |
           test\test.bat c:\msvc
 
   test-msvc-wine-versions:
+    needs: populate-cache
     runs-on: ubuntu-latest
     steps:
       - name: Install prerequisites
@@ -201,39 +281,47 @@ jobs:
           WINE=$(command -v wine64 || command -v wine || false)
           $WINE wineboot
       - uses: actions/checkout@v6
+      - name: Set up vsdownload cache
+        run: mkdir -p ~/.cache/vsdownload
+      - name: Cache vsdownload packages
+        uses: actions/cache/restore@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~/.cache/vsdownload
+          key: vsdownload
       - name: Download MSVC 2017 latest
         run: |
-          ./vsdownload.py --accept-license --dest $(pwd)/msvc --major 15
+          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache ~/.cache/vsdownload --major 15
           ./install.sh $(pwd)/msvc
           ./msvc/bin/x64/cl test/hello.c -Fehello.exe
           rm -rf msvc
       - name: Download MSVC 2019 latest
         run: |
-          ./vsdownload.py --accept-license --dest $(pwd)/msvc --major 16
+          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache ~/.cache/vsdownload --major 16
           ./install.sh $(pwd)/msvc
           ./msvc/bin/x64/cl test/hello.c -Fehello.exe
           rm -rf msvc
       - name: Download MSVC 2017 specific version
         run: |
-          ./vsdownload.py --accept-license --dest $(pwd)/msvc --major 15 --msvc-version 15.9
+          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache ~/.cache/vsdownload --major 15 --msvc-version 15.9
           ./install.sh $(pwd)/msvc
           ./msvc/bin/x64/cl test/hello.c -Fehello.exe
           rm -rf msvc
       - name: Download MSVC 2019 specific version
         run: |
-          ./vsdownload.py --accept-license --dest $(pwd)/msvc --major 16 --msvc-version 16.9
+          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache ~/.cache/vsdownload --major 16 --msvc-version 16.9
           ./install.sh $(pwd)/msvc
           ./msvc/bin/x64/cl test/hello.c -Fehello.exe
           rm -rf msvc
       - name: Download MSVC 2022 specific version
         run: |
-          ./vsdownload.py --accept-license --dest $(pwd)/msvc --major 17 --msvc-version 17.0
+          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache ~/.cache/vsdownload --major 17 --msvc-version 17.0
           ./install.sh $(pwd)/msvc
           ./msvc/bin/x64/cl test/hello.c -Fehello.exe
           rm -rf msvc
       - name: Download MSVC 2022 with non-default SDK
         run: |
-          ./vsdownload.py --accept-license --dest $(pwd)/msvc --major 17 --sdk-version 10.0.26100
+          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache ~/.cache/vsdownload --major 17 --sdk-version 10.0.26100
           ./install.sh $(pwd)/msvc
           ./msvc/bin/x64/cl test/hello.c -Fehello.exe
           rm -rf msvc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
           WINE=$(command -v wine64 || command -v wine || false)
           $WINE wineboot
           # Check https://gitlab.winehq.org/wine/wine/-/wikis/Wine-Mono#versions before updating the WINE package!
-          curl -s -L -O https://github.com/madewokherd/wine-mono/releases/download/wine-mono-8.1.0/wine-mono-8.1.0-x86.msi
-          $WINE msiexec /i wine-mono-8.1.0-x86.msi
+          curl -s -L -O https://github.com/wine-mono/wine-mono/releases/download/wine-mono-9.4.0/wine-mono-9.4.0-x86.msi
+          $WINE msiexec /i wine-mono-9.4.0-x86.msi
       - uses: actions/checkout@v6
       - name: Download MSVC
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     # Using a pinned version of Ubuntu here; this determines the version of
     # Wine that gets installed - the version of wine-mono that is installed
     # below depends on the host version of Wine.
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Install prerequisites
         run: |
@@ -37,7 +37,7 @@ jobs:
       # the installed files aren't redistributable!
 
   test-msvc-wine-linux-arm:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-26.04-arm
     # Use a custom base container for providing wine; the base Wine package
     # in Ubuntu 24.04 is broken on aarch64, see
     # https://bugs.launchpad.net/ubuntu/+source/wine/+bug/2102681 and
@@ -63,7 +63,7 @@ jobs:
       # the installed files aren't redistributable!
 
   test-msvc-wine-linux-arm-target-host-only:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-26.04-arm
     # Use a custom base container for providing wine; the base Wine package
     # in Ubuntu 24.04 is broken on aarch64, see
     # https://bugs.launchpad.net/ubuntu/+source/wine/+bug/2102681 and
@@ -115,7 +115,7 @@ jobs:
     # the /winsysroot parameter. LLD also provides the same parameter since
     # version 15. (For versions 13 and 14, this parameter can still be used
     # for linking, as long as linking is done via Clang.)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - name: Install prerequisites
         run: |

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -10,7 +10,23 @@ on:
       - 'lowercase'
 
 jobs:
+  populate-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Cache vsdownload packages
+        uses: actions/cache@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~/.cache/vsdownload
+          key: vsdownload
+      - name: Populate vsdownload cache
+        run: |
+          sudo apt-get update && sudo apt-get install -y python3 msitools
+          ./vsdownload.py --accept-license --only-download --cache ~/.cache/vsdownload
+
   test-build-dav1d:
+    needs: populate-cache
     runs-on: ubuntu-latest
     steps:
       - name: Install prerequisites
@@ -19,9 +35,17 @@ jobs:
           WINE=$(command -v wine64 || command -v wine || false)
           $WINE wineboot
       - uses: actions/checkout@v6
+      - name: Set up vsdownload cache
+        run: mkdir -p ~/.cache/vsdownload
+      - name: Cache vsdownload packages
+        uses: actions/cache/restore@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~/.cache/vsdownload
+          key: vsdownload
       - name: Download MSVC
         run: |
-          ./vsdownload.py --accept-license --dest $(pwd)/msvc --architecture arm64
+          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache ~/.cache/vsdownload --architecture arm64
           ./install.sh $(pwd)/msvc
       - name: Checkout gas-preprocessor
         uses: actions/checkout@v6
@@ -75,6 +99,7 @@ jobs:
           retention-days: 7
 
   test-build-ffmpeg:
+    needs: populate-cache
     runs-on: ubuntu-latest
     steps:
       - name: Install prerequisites
@@ -83,9 +108,17 @@ jobs:
           WINE=$(command -v wine64 || command -v wine || false)
           $WINE wineboot
       - uses: actions/checkout@v6
+      - name: Set up vsdownload cache
+        run: mkdir -p ~/.cache/vsdownload
+      - name: Cache vsdownload packages
+        uses: actions/cache/restore@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~/.cache/vsdownload
+          key: vsdownload
       - name: Download MSVC
         run: |
-          ./vsdownload.py --accept-license --dest $(pwd)/msvc --architecture arm64
+          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache ~/.cache/vsdownload --architecture arm64
           ./install.sh $(pwd)/msvc
       - name: Checkout gas-preprocessor
         uses: actions/checkout@v6
@@ -120,6 +153,7 @@ jobs:
           retention-days: 7
 
   test-build-llvm:
+    needs: populate-cache
     runs-on: ubuntu-latest
     steps:
       - name: Install prerequisites
@@ -128,9 +162,17 @@ jobs:
           WINE=$(command -v wine64 || command -v wine || false)
           $WINE wineboot
       - uses: actions/checkout@v6
+      - name: Set up vsdownload cache
+        run: mkdir -p ~/.cache/vsdownload
+      - name: Cache vsdownload packages
+        uses: actions/cache/restore@v5
+        with:
+          enableCrossOsArchive: true
+          path: ~/.cache/vsdownload
+          key: vsdownload
       - name: Download MSVC
         run: |
-          ./vsdownload.py --accept-license --dest $(pwd)/msvc --architecture x64
+          ./vsdownload.py --accept-license --dest $(pwd)/msvc --cache ~/.cache/vsdownload --architecture x64
           ./install.sh $(pwd)/msvc
       - name: Checkout llvm-project
         uses: actions/checkout@v6

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -67,7 +67,7 @@ jobs:
           cp ../../msvc/vc/Redist/MSVC/1*/arm64/*.CRT/vcruntime*.dll ../../install/bin
       # The build output from MSVC actually is redistributable, even if the
       # toolchain itself isn't.
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: dav1d
           path: |
@@ -112,7 +112,7 @@ jobs:
           make install
       # The build output from MSVC actually is redistributable, even if the
       # toolchain itself isn't.
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: ffmpeg
           path: |
@@ -163,7 +163,7 @@ jobs:
           cp ../../../msvc/vc/Redist/MSVC/1*/x64/*.CRT/vcruntime*.dll ../../../install/bin
       # The build output from MSVC actually is redistributable, even if the
       # toolchain itself isn't.
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: llvm
           path: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,32 @@
-FROM ubuntu:24.04
+# syntax=docker/dockerfile:1
+FROM ubuntu:26.04 AS base
 
-RUN apt-get update && \
-    apt-get install -y wine64 python3 msitools ca-certificates && \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/*
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt update && apt-get --no-install-recommends install -y \
+    ca-certificates \
+    gnupg \
+    msitools \
+    python3 \
+    wget \
+    wine
 
 # Initialize the wine environment. Wait until the wineserver process has
 # exited before closing the session, to avoid corrupting the wine prefix.
 RUN $(command -v wine64 || command -v wine || false) wineboot --init && \
     while pgrep wineserver > /dev/null; do sleep 1; done
 
+COPY --link lowercase fixinclude install.sh vsdownload.py msvctricks.cpp /opt/msvc/
+COPY --link wrappers/* /opt/msvc/wrappers/
+COPY --link msvcenv-native.sh /opt/msvc/
+
 WORKDIR /opt/msvc
 
-COPY lowercase fixinclude install.sh vsdownload.py msvctricks.cpp ./
-COPY wrappers/* ./wrappers/
-
-RUN PYTHONUNBUFFERED=1 ./vsdownload.py --accept-license --dest /opt/msvc && \
-    ./install.sh /opt/msvc && \
-    rm lowercase fixinclude install.sh vsdownload.py && \
-    rm -rf wrappers
-
-COPY msvcenv-native.sh /opt/msvc
+RUN --mount=type=cache,target=/var/cache/vsdownload,sharing=locked \
+    PYTHONUNBUFFERED=1 ./vsdownload.py --accept-license \
+      --cache=/var/cache/vsdownload --dest=/opt/msvc && \
+    ./install.sh /opt/msvc
 
 # Later stages which actually uses MSVC can ideally start a persistent
 # wine server like this:

--- a/Dockerfile.clang
+++ b/Dockerfile.clang
@@ -1,28 +1,22 @@
+# syntax=docker/dockerfile:1
 ARG BASE=msvc-wine
 FROM $BASE
 
-RUN apt-get update && \
-    apt-get install -y curl xz-utils && \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt update && apt-get --no-install-recommends install -y \
+    clang \
+    clang-tools \
+    lld
 
-# Newer versions of Ubuntu also provide a new enough version of Clang/lld
-# to work with MSVC 2022 headers/libs, but clang-cl is only available with
-# a version suffix, like "clang-cl-14" anyway.
-RUN curl -LO https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz && \
-    tar -Jxf clang+llvm*.tar.xz && \
-    rm clang+llvm*.tar.xz && \
-    mv clang+llvm* /opt/clang
-
-ENV PATH=/opt/clang/bin:$PATH
-
-COPY test/hello.c ./
+COPY --link test/hello.c ./
 
 RUN \
+    clang_cl="$(find /usr/bin -regextype posix-extended -regex '.*/clang-cl(-[0-9]+)?$' -printf '%f\n' | sort -V | tail -n1)"; \
     for arch in x86 x64 arm arm64; do \
         [ ! -d /opt/msvc/kits/10/lib/*/um/$arch ] || \
         (BIN=/opt/msvc/bin/$arch . /opt/msvc/msvcenv-native.sh && \
-            clang-cl --target=$TARGET_TRIPLE hello.c -fuse-ld=lld -Fehello-$arch.exe && \
+            "$clang_cl" --target=$TARGET_TRIPLE hello.c -fuse-ld=lld -Fehello-$arch.exe && \
             clang --target=$TARGET_TRIPLE hello.c -fuse-ld=lld -o hello-$arch.exe \
         ) || exit 1; \
     done

--- a/Dockerfile.hello
+++ b/Dockerfile.hello
@@ -1,10 +1,11 @@
+# syntax=docker/dockerfile:1
 ARG BASE=msvc-wine
 FROM $BASE
 
-COPY test/hello.c ./
+COPY --link test/hello.c ./
 
 RUN \
-    wineserver -p && \
+    "$(command -v wineserver || find /usr/lib -path '*/wine/wineserver' -type f | head -n1)" -p && \
     $(command -v wine64 || command -v wine || false) wineboot && \
     for arch in x86 x64 arm arm64; do \
         [ ! -d /opt/msvc/kits/10/lib/*/um/$arch ] || \


### PR DESCRIPTION
This PR can be reviewed commit-by-commit, I was a bit lazy and did not split it out.

- [github: update to upload-artifact@v7 action](https://github.com/mstorsjo/msvc-wine/commit/8c30aaf1bdaba02ebe9033350901ded0ef6fcea9)
- [github: update jobs to Ubuntu 26.04](https://github.com/mstorsjo/msvc-wine/commit/9f1958f7097817555199434536012d73c79bca71)
- [github: update wine-mono](https://github.com/mstorsjo/msvc-wine/commit/f5a0125730cd282eadcd08786d90b5cfd4e01580)
  Ubuntu 26.04 packages Wine 10.
- [docker: use BuildKit and optimize cache](https://github.com/mstorsjo/msvc-wine/commit/67d7be3c631be29ba827455bf3a8b104c7c4202a)
  - Update the Dockerfiles to use the BuildKit syntax. This allows for more efficient copy of files from the context, see [`--link`](https://docs.docker.com/reference/dockerfile/#copy---link).
  - Use cache mounts for apt packages and for VS packages. Super useful when the `RUN` line is invalidated and it would otherwise re-download a ton of packages. The caches are _mounted_ during the image build, can be re-used and shared across builds, and are not committed into the images. Saves a _ton_ of time on bad connection.
    https://docs.docker.com/build/cache/optimize/#use-cache-mounts
    https://docs.docker.com/reference/dockerfile/#example-cache-apt-packages
  - Update to Ubuntu 26.04. Find the latest clang-cl, and find wineserver in its new location.
- [github: cross-os caching of the VS packages](https://github.com/mstorsjo/msvc-wine/commit/c76dee637b617f662a857f379b2c1da6d0a9d898)
  Cache the VS packages in GitHub Actions. Share the cache between Linux, macOS, and Windows. Populate the cache before running the jobs, to make sure that the jobs are not competing to create the cache. Should save about a minute on each test using the cache. And saves bandwidth.
  
Thanks for the hard and useful work!