### PR TITLE
macOS Apple Silicon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ To install, just run the following two commands:
     ./install.sh <dir>
 
 The unpacking requires recent versions of msitools (0.98) and libgcab
-(1.2); sufficiently new versions are available in e.g. Ubuntu 19.04.
+(1.2); sufficiently new versions are available in e.g. Ubuntu 19.04. On macOS,
+you can install the prerequisites via Homebrew: `brew install wine-stable msitools meson`.
 
 After installing the toolchain this way, there are 4 directories with tools,
 in `<dest>/bin/<arch>`, for all architectures out of `x86`,
@@ -88,9 +89,13 @@ To use clang/lld with MSVC/WinSDK headers provided by msvc-wine, first download 
 as usual. You need less prerequisites as wine won't be needed:
 
 ```bash
+# On Debian/Ubuntu:
 apt-get update
 apt-get install -y python3 msitools ca-certificates
 
+# On macOS, Apple Clang does not include clang-cl or lld-link. 
+# You must install LLVM via Homebrew: brew install msitools llvm
+```
 # Download and unpack MSVC
 ./vsdownload.py --dest ~/my_msvc
 # Clean up headers, add scripts for setting up the environments

--- a/install.sh
+++ b/install.sh
@@ -180,9 +180,11 @@ done
 host=x64
 # .NET-based tools use different host arch directories
 dotnet_host=amd64
-if [ "$(uname -m)" = "aarch64" ]; then
-    host=arm64
-    dotnet_host=arm64
+if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
+    if [ "$(uname -s)" != "Darwin" ]; then
+        host=arm64
+        dotnet_host=arm64
+    fi
 fi
 
 # Support `import std` for CMake.

--- a/test/test-vcvars.sh
+++ b/test/test-vcvars.sh
@@ -17,8 +17,10 @@
 . "${0%/*}/test.sh"
 
 host=x64
-if [ "$(uname -m)" = "aarch64" ]; then
-    host=arm64
+if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
+    if [ "$(uname -s)" != "Darwin" ]; then
+        host=arm64
+    fi
 fi
 
 BASE=$(. "${BIN}msvcenv.sh" && echo $BASE)

--- a/vsdownload.py
+++ b/vsdownload.py
@@ -926,6 +926,14 @@ if __name__ == "__main__":
     parser = getArgsParser()
     args = parser.parse_args()
 
+    if sys.platform != "win32" and not shutil.which("msiextract"):
+        print("Error: 'msiextract' (part of msitools) is required but not found in PATH.")
+        if platform.system() == "Darwin":
+            print("On macOS, you can install it via: brew install msitools")
+        else:
+            print("On Debian/Ubuntu, you can install it via: apt-get install msitools")
+        sys.exit(1)
+
     socket.setdefaulttimeout(15)
 
     if args.host_arch is None:


### PR DESCRIPTION
* Update `install.sh` and `test/test-vcvars.sh` to treat Apple Silicon (`arm64`) as host `x64`, as Wine on macOS requires running x86_64 architecture wrappers natively under Rosetta 2.
* Add `msiextract` early error-handling to `vsdownload.py` with explicit instructions for `brew install msitools`.
* Document Homebrew requirements (`wine-stable`, `msitools`, `meson`, `llvm`) in the README.